### PR TITLE
Release Candidate v3.5.0

### DIFF
--- a/CreatePetalinuxProject.sh
+++ b/CreatePetalinuxProject.sh
@@ -193,7 +193,7 @@ fi
 
 # #######################################################################################
 # # python3-setuptools_dso-native (host) has arch=linux-x86_64 and is being used for EPICS_HOST_ARCH
-# # The -native package required to make python-setup work, but -native package will have a linux-x86_64 
+# # The -native package required to make python-setup work, but -native package will have a linux-x86_64
 # # of epicscorelibs/lib/libCom.so used and incompatible with aarch64
 # # TODO: Figure out who to get python3-setuptools_dso to set EPICS_HOST_ARCH=aarch64 in future
 # #######################################################################################

--- a/CreatePetalinuxProject.sh
+++ b/CreatePetalinuxProject.sh
@@ -113,7 +113,7 @@ if [ -d "$hwDir/patch" ]
 then
    # Add the patches to the petalinux project
    for filename in $(ls -p $hwDir/patch); do
-      echo SRC_URI_append = \" file://$filename\" >> project-spec/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
+      echo SRC_URI:append = \" file://$filename\" >> project-spec/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
       cp -f $hwDir/patch/$filename project-spec/meta-user/recipes-kernel/linux/linux-xlnx/.
    done
 fi

--- a/hardware/RealDigitalRfSoC4x2/xdc/RealDigitalRfSoC4x2.xdc
+++ b/hardware/RealDigitalRfSoC4x2/xdc/RealDigitalRfSoC4x2.xdc
@@ -48,35 +48,35 @@ set_property -dict { PACKAGE_PIN AU10 IOSTANDARD LVCMOS18 } [get_ports { userLed
 
 ##############################################################################
 
-# ADC TILE 224
-set_property PACKAGE_PIN AP2 [get_ports { adcP[0] }]
-set_property PACKAGE_PIN AP1 [get_ports { adcN[0] }]
-set_property PACKAGE_PIN AM2 [get_ports { adcP[1] }]
-set_property PACKAGE_PIN AM1 [get_ports { adcN[1] }]
-set_property PACKAGE_PIN AF5 [get_ports { adcClkP[0] }]
-set_property PACKAGE_PIN AF4 [get_ports { adcClkN[0] }]
+## ADC TILE 224
+#set_property PACKAGE_PIN AP2 [get_ports { adcP[0] }]
+#set_property PACKAGE_PIN AP1 [get_ports { adcN[0] }]
+#set_property PACKAGE_PIN AM2 [get_ports { adcP[1] }]
+#set_property PACKAGE_PIN AM1 [get_ports { adcN[1] }]
+#set_property PACKAGE_PIN AF5 [get_ports { adcClkP[0] }]
+#set_property PACKAGE_PIN AF4 [get_ports { adcClkN[0] }]
 
-# ADC TILE 226
-set_property PACKAGE_PIN AF2 [get_ports { adcP[2] }]
-set_property PACKAGE_PIN AF1 [get_ports { adcN[2] }]
-set_property PACKAGE_PIN AD2 [get_ports { adcP[3] }]
-set_property PACKAGE_PIN AD1 [get_ports { adcN[3] }]
-set_property PACKAGE_PIN AB5 [get_ports { adcClkP[1] }]
-set_property PACKAGE_PIN AB4 [get_ports { adcClkN[1] }]
+## ADC TILE 226
+#set_property PACKAGE_PIN AF2 [get_ports { adcP[2] }]
+#set_property PACKAGE_PIN AF1 [get_ports { adcN[2] }]
+#set_property PACKAGE_PIN AD2 [get_ports { adcP[3] }]
+#set_property PACKAGE_PIN AD1 [get_ports { adcN[3] }]
+#set_property PACKAGE_PIN AB5 [get_ports { adcClkP[1] }]
+#set_property PACKAGE_PIN AB4 [get_ports { adcClkN[1] }]
 
-# DAC TILE 228
-set_property PACKAGE_PIN U2 [get_ports { dacP[0] }]
-set_property PACKAGE_PIN U1 [get_ports { dacN[0] }]
-set_property PACKAGE_PIN R5 [get_ports { dacClkP[0] }]
-set_property PACKAGE_PIN R4 [get_ports { dacClkN[0] }]
-set_property PACKAGE_PIN U5 [get_ports { sysRefP }]
-set_property PACKAGE_PIN U4 [get_ports { sysRefN }]
+## DAC TILE 228
+#set_property PACKAGE_PIN U2 [get_ports { dacP[0] }]
+#set_property PACKAGE_PIN U1 [get_ports { dacN[0] }]
+#set_property PACKAGE_PIN R5 [get_ports { dacClkP[0] }]
+#set_property PACKAGE_PIN R4 [get_ports { dacClkN[0] }]
+#set_property PACKAGE_PIN U5 [get_ports { sysRefP }]
+#set_property PACKAGE_PIN U4 [get_ports { sysRefN }]
 
-# DAC TILE 230
-set_property PACKAGE_PIN J2 [get_ports { dacP[1] }]
-set_property PACKAGE_PIN J1 [get_ports { dacN[1] }]
-set_property PACKAGE_PIN N5 [get_ports { dacClkP[1] }]
-set_property PACKAGE_PIN N4 [get_ports { dacClkN[1] }]
+## DAC TILE 230
+#set_property PACKAGE_PIN J2 [get_ports { dacP[1] }]
+#set_property PACKAGE_PIN J1 [get_ports { dacN[1] }]
+#set_property PACKAGE_PIN N5 [get_ports { dacClkP[1] }]
+#set_property PACKAGE_PIN N4 [get_ports { dacClkN[1] }]
 
 ##############################################################################
 

--- a/hardware/XilinxZcu670/xdc/XilinxZcu670.xdc
+++ b/hardware/XilinxZcu670/xdc/XilinxZcu670.xdc
@@ -67,70 +67,70 @@ set_property -dict { PACKAGE_PIN G12 IOSTANDARD LVCMOS12 } [get_ports { clkMuxSe
 
 ##############################################################################
 
-set_property PACKAGE_PIN AD5 [get_ports { adcClkP[0] }]; # TILE 225 (Si5381A.OUT3)
-set_property PACKAGE_PIN AD4 [get_ports { adcClkN[0] }]; # TILE 225 (Si5381A.OUT3B)
+# set_property PACKAGE_PIN AD5 [get_ports { adcClkP[0] }]; # TILE 225 (Si5381A.OUT3)
+# set_property PACKAGE_PIN AD4 [get_ports { adcClkN[0] }]; # TILE 225 (Si5381A.OUT3B)
 
-set_property PACKAGE_PIN AB5 [get_ports { adcClkP[1] }]; # TILE 226 (J8  - SSMP Connector)
-set_property PACKAGE_PIN AB4 [get_ports { adcClkN[1] }]; # TILE 226 (J98 - SSMP Connector)
+# set_property PACKAGE_PIN AB5 [get_ports { adcClkP[1] }]; # TILE 226 (J8  - SSMP Connector)
+# set_property PACKAGE_PIN AB4 [get_ports { adcClkN[1] }]; # TILE 226 (J98 - SSMP Connector)
 
-set_property PACKAGE_PIN L5 [get_ports { dacClkP[0] }]; # TILE 227 (Si5381A.OUT0)
-set_property PACKAGE_PIN L4 [get_ports { dacClkN[0] }]; # TILE 227 (Si5381A.OUT0B)
+# set_property PACKAGE_PIN L5 [get_ports { dacClkP[0] }]; # TILE 227 (Si5381A.OUT0)
+# set_property PACKAGE_PIN L4 [get_ports { dacClkN[0] }]; # TILE 227 (Si5381A.OUT0B)
 
-set_property PACKAGE_PIN J5 [get_ports { dacClkP[1] }]; # TILE 228 (J99  - SSMP Connector)
-set_property PACKAGE_PIN J4 [get_ports { dacClkN[1] }]; # TILE 228 (J100 - SSMP Connector)
+# set_property PACKAGE_PIN J5 [get_ports { dacClkP[1] }]; # TILE 228 (J99  - SSMP Connector)
+# set_property PACKAGE_PIN J4 [get_ports { dacClkN[1] }]; # TILE 228 (J100 - SSMP Connector)
 
-set_property PACKAGE_PIN N5 [get_ports { sysRefP }]
-set_property PACKAGE_PIN N4 [get_ports { sysRefN }]
+# set_property PACKAGE_PIN N5 [get_ports { sysRefP }]
+# set_property PACKAGE_PIN N4 [get_ports { sysRefN }]
 
-# ADC TILE 224
-set_property PACKAGE_PIN AK2 [get_ports { adcP[0] }]
-set_property PACKAGE_PIN AK1 [get_ports { adcN[0] }]
-set_property PACKAGE_PIN AH2 [get_ports { adcP[1] }]
-set_property PACKAGE_PIN AH1 [get_ports { adcN[1] }]
+# # ADC TILE 224
+# set_property PACKAGE_PIN AK2 [get_ports { adcP[0] }]
+# set_property PACKAGE_PIN AK1 [get_ports { adcN[0] }]
+# set_property PACKAGE_PIN AH2 [get_ports { adcP[1] }]
+# set_property PACKAGE_PIN AH1 [get_ports { adcN[1] }]
 
-set_property PACKAGE_PIN AF2 [get_ports { adcP[2] }]
-set_property PACKAGE_PIN AF1 [get_ports { adcN[2] }]
-set_property PACKAGE_PIN AD2 [get_ports { adcP[3] }]
-set_property PACKAGE_PIN AD1 [get_ports { adcN[3] }]
+# set_property PACKAGE_PIN AF2 [get_ports { adcP[2] }]
+# set_property PACKAGE_PIN AF1 [get_ports { adcN[2] }]
+# set_property PACKAGE_PIN AD2 [get_ports { adcP[3] }]
+# set_property PACKAGE_PIN AD1 [get_ports { adcN[3] }]
 
-# ADC TILE 225
-set_property PACKAGE_PIN AB2 [get_ports { adcP[4] }]
-set_property PACKAGE_PIN AB1 [get_ports { adcN[4] }]
-set_property PACKAGE_PIN Y2  [get_ports { adcP[5] }]
-set_property PACKAGE_PIN Y1  [get_ports { adcN[5] }]
+# # ADC TILE 225
+# set_property PACKAGE_PIN AB2 [get_ports { adcP[4] }]
+# set_property PACKAGE_PIN AB1 [get_ports { adcN[4] }]
+# set_property PACKAGE_PIN Y2  [get_ports { adcP[5] }]
+# set_property PACKAGE_PIN Y1  [get_ports { adcN[5] }]
 
-set_property PACKAGE_PIN V2 [get_ports { adcP[6] }]
-set_property PACKAGE_PIN V1 [get_ports { adcN[6] }]
-set_property PACKAGE_PIN T2 [get_ports { adcP[7] }]
-set_property PACKAGE_PIN T1 [get_ports { adcN[7] }]
+# set_property PACKAGE_PIN V2 [get_ports { adcP[6] }]
+# set_property PACKAGE_PIN V1 [get_ports { adcN[6] }]
+# set_property PACKAGE_PIN T2 [get_ports { adcP[7] }]
+# set_property PACKAGE_PIN T1 [get_ports { adcN[7] }]
 
-# ADC TILE 226
-set_property PACKAGE_PIN Y4 [get_ports { adcP[8] }]
-set_property PACKAGE_PIN Y5 [get_ports { adcN[8] }]
-set_property PACKAGE_PIN V4 [get_ports { adcP[9] }]
-set_property PACKAGE_PIN V5 [get_ports { adcN[9] }]
+# # ADC TILE 226
+# set_property PACKAGE_PIN Y4 [get_ports { adcP[8] }]
+# set_property PACKAGE_PIN Y5 [get_ports { adcN[8] }]
+# set_property PACKAGE_PIN V4 [get_ports { adcP[9] }]
+# set_property PACKAGE_PIN V5 [get_ports { adcN[9] }]
 
-# DAC TILE 227
-set_property PACKAGE_PIN N2 [get_ports { dacP[0] }]
-set_property PACKAGE_PIN N1 [get_ports { dacN[0] }]
-set_property PACKAGE_PIN L2 [get_ports { dacP[1] }]
-set_property PACKAGE_PIN L1 [get_ports { dacN[1] }]
+# # DAC TILE 227
+# set_property PACKAGE_PIN N2 [get_ports { dacP[0] }]
+# set_property PACKAGE_PIN N1 [get_ports { dacN[0] }]
+# set_property PACKAGE_PIN L2 [get_ports { dacP[1] }]
+# set_property PACKAGE_PIN L1 [get_ports { dacN[1] }]
 
-set_property PACKAGE_PIN J2 [get_ports { dacP[2] }]
-set_property PACKAGE_PIN J1 [get_ports { dacN[2] }]
-set_property PACKAGE_PIN G2 [get_ports { dacP[3] }]
-set_property PACKAGE_PIN G1 [get_ports { dacN[3] }]
+# set_property PACKAGE_PIN J2 [get_ports { dacP[2] }]
+# set_property PACKAGE_PIN J1 [get_ports { dacN[2] }]
+# set_property PACKAGE_PIN G2 [get_ports { dacP[3] }]
+# set_property PACKAGE_PIN G1 [get_ports { dacN[3] }]
 
-# DAC TILE 228
-set_property PACKAGE_PIN E2 [get_ports { dacP[4] }]
-set_property PACKAGE_PIN E1 [get_ports { dacN[4] }]
-set_property PACKAGE_PIN C2 [get_ports { dacP[5] }]
-set_property PACKAGE_PIN C1 [get_ports { dacN[5] }]
+# # DAC TILE 228
+# set_property PACKAGE_PIN E2 [get_ports { dacP[4] }]
+# set_property PACKAGE_PIN E1 [get_ports { dacN[4] }]
+# set_property PACKAGE_PIN C2 [get_ports { dacP[5] }]
+# set_property PACKAGE_PIN C1 [get_ports { dacN[5] }]
 
-set_property PACKAGE_PIN B4 [get_ports { dacP[6] }]
-set_property PACKAGE_PIN A4 [get_ports { dacN[6] }]
-set_property PACKAGE_PIN B6 [get_ports { dacP[7] }]
-set_property PACKAGE_PIN A6 [get_ports { dacN[7] }]
+# set_property PACKAGE_PIN B4 [get_ports { dacP[6] }]
+# set_property PACKAGE_PIN A4 [get_ports { dacN[6] }]
+# set_property PACKAGE_PIN B6 [get_ports { dacP[7] }]
+# set_property PACKAGE_PIN A6 [get_ports { dacN[7] }]
 
 ##############################################################################
 

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_SigToAxiStream.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_SigToAxiStream.py
@@ -1,0 +1,64 @@
+#-----------------------------------------------------------------------------
+# This file is part of the 'axi-soc-ultra-plus-core'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'axi-soc-ultra-plus-core', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+class SigToAxiStream(pr.Device):
+    def __init__(self,axiCtrl=False,**kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.RemoteVariable(
+            name         = 'DATA_BYTES_G',
+            description  = 'Data Width VHDL Generic configuration',
+            offset       = 0x0,
+            bitSize      = 8,
+            bitOffset    = 0,
+            mode         = 'RO',
+            disp         = '{:d}',
+            units        = 'bytes',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'WRD_CNT_WIDTH_G',
+            description  = 'Word Counter Bit Width VHDL Generic configuration',
+            offset       = 0x0,
+            bitSize      = 8,
+            bitOffset    = 8,
+            mode         = 'RO',
+            disp         = '{:d}',
+            units        = 'Bit',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'WordSize',
+            description  = 'Length of AXI stream burst (zero inclusive)',
+            offset       = 0x4,
+            bitSize      = 32,
+            mode         = 'RW' if axiCtrl else 'RO',
+            units        = 'DATA_BYTES_G',
+        ))
+
+        self.add(pr.RemoteCommand(
+            name         = 'SwTrig',
+            description  = 'Force a AXI stream burst from software',
+            offset       = 0x8,
+            bitSize      = 1,
+            function     = lambda cmd: cmd.post(1),
+            # hidden       = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'ContinuousMode',
+            description  = 'Continuous trigger mode',
+            offset       = 0xC,
+            bitSize      = 1,
+            mode         = 'RW',
+            hidden       = not axiCtrl,
+        ))

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/__init__.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/__init__.py
@@ -1,4 +1,5 @@
 from axi_soc_ultra_plus_core.rfsoc_utility._AppRingBuffer       import *
 from axi_soc_ultra_plus_core.rfsoc_utility._SigGen              import *
 from axi_soc_ultra_plus_core.rfsoc_utility._SigGenLoader        import *
+from axi_soc_ultra_plus_core.rfsoc_utility._SigToAxiStream      import *
 from axi_soc_ultra_plus_core.rfsoc_utility._RingBufferProcessor import *

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/gui/_LiveDisplay.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/gui/_LiveDisplay.py
@@ -53,8 +53,20 @@ class LiveDisplay(PyDMFrame):
         self.freqPlot.removeChannelAtIndex(0)
 
         # Add new curve item with respect to channel select
-        self.timePlot.addChannel(x_channel=f'{self.path[self.idx]}.Time', y_channel=f'{self.path[self.idx]}.WaveformData', color=self.color[self.idx])
-        self.freqPlot.addChannel(x_channel=f'{self.path[self.idx]}.Freq', y_channel=f'{self.path[self.idx]}.Magnitude', color=self.color[self.idx])
+        self.timePlot.addChannel(
+            x_channel  = f'{self.path[self.idx]}.Time',
+            y_channel  = f'{self.path[self.idx]}.WaveformData',
+            color      = self.color[self.idx],
+            symbol     = 'o',
+            symbolSize = 3,
+        )
+        self.freqPlot.addChannel(
+            x_channel  = f'{self.path[self.idx]}.Freq',
+            y_channel  = f'{self.path[self.idx]}.Magnitude',
+            color      = self.color[self.idx],
+            symbol     = 'o',
+            symbolSize = 3,
+        )
 
         # Reset the auto-ranging
         self.resetScales()

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBuffer.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBuffer.vhd
@@ -36,6 +36,8 @@ entity AppRingBuffer is
       RAM_ADDR_WIDTH_G       : positive := 9;
       MEMORY_TYPE_G          : string   := "block";
       COMMON_CLK_G           : boolean  := false;  -- true if dataClk=axilClk
+      FIFO_MEMORY_TYPE_G     : string   := "block";
+      FIFO_ADDR_WIDTH_G      : positive := 9;
       AXIL_BASE_ADDR_G       : slv(31 downto 0));
    port (
       -- DMA Interface (dmaClk domain)
@@ -155,6 +157,8 @@ begin
             RAM_ADDR_WIDTH_G   => RAM_ADDR_WIDTH_G,
             MEMORY_TYPE_G      => MEMORY_TYPE_G,
             COMMON_CLK_G       => COMMON_CLK_G,
+            FIFO_MEMORY_TYPE_G => FIFO_MEMORY_TYPE_G,
+            FIFO_ADDR_WIDTH_G  => FIFO_ADDR_WIDTH_G,
             AXIL_BASE_ADDR_G   => AXIL_CONFIG_C(ADC_RING_INDEX_C).baseAddr)
          port map (
             -- AXI-Stream Interface (axisClk domain)

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBuffer.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBuffer.vhd
@@ -34,6 +34,8 @@ entity AppRingBuffer is
       ADC_SAMPLE_PER_CYCLE_G : positive := 16;
       DAC_SAMPLE_PER_CYCLE_G : positive := 16;
       RAM_ADDR_WIDTH_G       : positive := 9;
+      MEMORY_TYPE_G          : string   := "block";
+      COMMON_CLK_G           : boolean  := false;  -- true if dataClk=axilClk
       AXIL_BASE_ADDR_G       : slv(31 downto 0));
    port (
       -- DMA Interface (dmaClk domain)
@@ -151,6 +153,8 @@ begin
             NUM_CH_G           => NUM_ADC_CH_G,
             SAMPLE_PER_CYCLE_G => ADC_SAMPLE_PER_CYCLE_G,
             RAM_ADDR_WIDTH_G   => RAM_ADDR_WIDTH_G,
+            MEMORY_TYPE_G      => MEMORY_TYPE_G,
+            COMMON_CLK_G       => COMMON_CLK_G,
             AXIL_BASE_ADDR_G   => AXIL_CONFIG_C(ADC_RING_INDEX_C).baseAddr)
          port map (
             -- AXI-Stream Interface (axisClk domain)

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
@@ -29,6 +29,8 @@ entity AppRingBufferEngine is
       NUM_CH_G           : positive               := 8;
       SAMPLE_PER_CYCLE_G : positive               := 16;
       RAM_ADDR_WIDTH_G   : positive               := 10;
+      MEMORY_TYPE_G      : string                 := "block";
+      COMMON_CLK_G       : boolean                := false;  -- true if dataClk=axilClk
       TDEST_ROUTES_G     : Slv8Array(15 downto 0) := (others => x"00");
       AXIL_BASE_ADDR_G   : slv(31 downto 0));
    port (
@@ -125,6 +127,8 @@ begin
          generic map (
             TPD_G               => TPD_G,
             SYNTH_MODE_G        => "xpm",
+            MEMORY_TYPE_G       => MEMORY_TYPE_G,
+            COMMON_CLK_G        => COMMON_CLK_G,
             DATA_BYTES_G        => ((16*SAMPLE_PER_CYCLE_G)/8),
             RAM_ADDR_WIDTH_G    => RAM_ADDR_WIDTH_G,
             -- AXI Stream Configurations

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
@@ -31,6 +31,8 @@ entity AppRingBufferEngine is
       RAM_ADDR_WIDTH_G   : positive               := 10;
       MEMORY_TYPE_G      : string                 := "block";
       COMMON_CLK_G       : boolean                := false;  -- true if dataClk=axilClk
+      FIFO_MEMORY_TYPE_G : string                 := "block";
+      FIFO_ADDR_WIDTH_G  : positive               := 9;
       TDEST_ROUTES_G     : Slv8Array(15 downto 0) := (others => x"00");
       AXIL_BASE_ADDR_G   : slv(31 downto 0));
    port (
@@ -132,6 +134,8 @@ begin
             DATA_BYTES_G        => ((16*SAMPLE_PER_CYCLE_G)/8),
             RAM_ADDR_WIDTH_G    => RAM_ADDR_WIDTH_G,
             -- AXI Stream Configurations
+            FIFO_MEMORY_TYPE_G  => FIFO_MEMORY_TYPE_G,
+            FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
             GEN_SYNC_FIFO_G     => false,
             AXI_STREAM_CONFIG_G => DMA_AXIS_CONFIG_C)
          port map (

--- a/shared/rfsoc-utility/SigToAxiStream/rtl/SigToAxiStream.vhd
+++ b/shared/rfsoc-utility/SigToAxiStream/rtl/SigToAxiStream.vhd
@@ -1,0 +1,290 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Module to convert a waveform data bus into AXI stream
+-------------------------------------------------------------------------------
+-- This file is part of 'axi-soc-ultra-plus-core'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-soc-ultra-plus-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.SsiPkg.all;
+
+entity SigToAxiStream is
+   generic (
+      TPD_G               : time     := 1 ns;
+      RST_ASYNC_G         : boolean  := false;
+      COMMON_CLK_G        : boolean  := false;  -- true if dataClk=axilClk
+      DATA_BYTES_G        : positive;
+      WRD_CNT_WIDTH_G     : positive;
+      -- AXI Stream Configurations
+      VALID_THOLD_G       : natural  := 1;
+      VALID_BURST_MODE_G  : boolean  := false;
+      INT_PIPE_STAGES_G   : natural  := 1;
+      PIPE_STAGES_G       : natural  := 1;
+      GEN_SYNC_FIFO_G     : boolean  := false;  -- true if dataClk=axisClk
+      SYNTH_MODE_G        : string   := "inferred";
+      FIFO_MEMORY_TYPE_G  : string   := "block";
+      FIFO_ADDR_WIDTH_G   : positive := 10;
+      AXI_STREAM_CONFIG_G : AxiStreamConfigType);
+   port (
+      -- Data to store in ring buffer (dataClk domain)
+      dataClk         : in  sl;
+      dataRst         : in  sl := '0';
+      dataValid       : in  sl := '1';
+      dataValue       : in  slv(8*DATA_BYTES_G-1 downto 0);
+      extTrig         : in  sl := '0';
+      -- AXI-Lite interface (axilClk domain)
+      axilClk         : in  sl;
+      axilRst         : in  sl;
+      axilReadMaster  : in  AxiLiteReadMasterType;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType;
+      axilWriteSlave  : out AxiLiteWriteSlaveType;
+      -- AXI-Stream Interface (axisClk domain)
+      axisClk         : in  sl;
+      axisRst         : in  sl;
+      axisMaster      : out AxiStreamMasterType;
+      axisSlave       : in  AxiStreamSlaveType);
+end SigToAxiStream;
+
+architecture mapping of SigToAxiStream is
+
+   constant AXIS_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(
+      dataBytes => DATA_BYTES_G,
+      tKeepMode => TKEEP_FIXED_C,
+      tUserMode => TUSER_FIRST_LAST_C,
+      tDestBits => 0,
+      tUserBits => 2,
+      tIdBits   => 0);
+
+   type StateType is (
+      IDLE_S,
+      MOVE_S);
+
+   type RegType is record
+      sof        : sl;
+      eofe       : sl;
+      continuous : sl;
+      intTrig    : sl;
+      extTrig    : sl;
+      wordCnt    : slv(WRD_CNT_WIDTH_G-1 downto 0);
+      wordSize   : slv(WRD_CNT_WIDTH_G-1 downto 0);
+      readSlave  : AxiLiteReadSlaveType;
+      writeSlave : AxiLiteWriteSlaveType;
+      txMaster   : AxiStreamMasterType;
+      state      : StateType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      sof        => '0',
+      eofe       => '0',
+      continuous => '0',
+      intTrig    => '0',
+      extTrig    => '0',
+      wordCnt    => (others => '0'),
+      wordSize   => (others => '1'),    -- Preset to max size
+      readSlave  => AXI_LITE_READ_SLAVE_INIT_C,
+      writeSlave => AXI_LITE_WRITE_SLAVE_INIT_C,
+      txMaster   => axiStreamMasterInit(AXIS_CONFIG_C),
+      state      => IDLE_S);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal readMaster  : AxiLiteReadMasterType;
+   signal writeMaster : AxiLiteWriteMasterType;
+   signal txSlave     : AxiStreamSlaveType;
+
+
+begin
+
+   U_AxiLiteAsync : entity surf.AxiLiteAsync
+      generic map (
+         TPD_G           => TPD_G,
+         RST_ASYNC_G     => RST_ASYNC_G,
+         COMMON_CLK_G    => COMMON_CLK_G,
+         NUM_ADDR_BITS_G => 8)
+      port map (
+         -- Slave Interface
+         sAxiClk         => axilClk,
+         sAxiClkRst      => axilRst,
+         sAxiReadMaster  => axilReadMaster,
+         sAxiReadSlave   => axilReadSlave,
+         sAxiWriteMaster => axilWriteMaster,
+         sAxiWriteSlave  => axilWriteSlave,
+         -- Master Interface
+         mAxiClk         => dataClk,
+         mAxiClkRst      => dataRst,
+         mAxiReadMaster  => readMaster,
+         mAxiReadSlave   => r.readSlave,
+         mAxiWriteMaster => writeMaster,
+         mAxiWriteSlave  => r.writeSlave);
+
+   comb : process (dataRst, dataValid, dataValue, extTrig, r, readMaster,
+                   txSlave, writeMaster) is
+      variable v      : RegType;
+      variable axilEp : AxiLiteEndpointType;
+   begin
+      -- Latch the current value
+      v := r;
+
+      -- Reset flags
+      v.intTrig := '0';
+
+      ------------------------
+      -- AXI-Lite Transactions
+      ------------------------
+
+      -- Determine the transaction type
+      axiSlaveWaitTxn(axilEp, writeMaster, readMaster, v.writeSlave, v.readSlave);
+
+      axiSlaveRegisterR(axilEp, x"0", 0, toSlv(DATA_BYTES_G, 8));
+      axiSlaveRegisterR(axilEp, x"0", 8, toSlv(WRD_CNT_WIDTH_G, 8));
+      axiSlaveRegister (axilEp, x"4", 0, v.wordSize);
+      axiSlaveRegister (axilEp, x"8", 0, v.intTrig);
+      axiSlaveRegister (axilEp, x"C", 0, v.continuous);
+
+      -- Close the transaction
+      axiSlaveDefault(axilEp, v.writeSlave, v.readSlave, AXI_RESP_DECERR_C);
+
+      ------------------------
+      -- Local Trigger Logic
+      ------------------------
+
+      -- AXI Stream Flow Control
+      if (txSlave.tReady = '1') then
+         v.txMaster := axiStreamMasterInit(AXIS_CONFIG_C);
+      end if;
+
+      -- Sample the external trigger
+      v.extTrig := extTrig;
+
+      case r.state is
+         ----------------------------------------------------------------------
+         when IDLE_S =>
+            -- Reset the counters and flags
+            v.wordCnt := (others => '0');
+            v.sof     := '1';
+            v.eofe    := '0';
+
+            -- Check for start condition
+            if (r.extTrig = '0' and v.extTrig = '1') or (r.intTrig = '1') or (r.continuous = '1') then
+
+               -- Next state
+               v.state := MOVE_S;
+
+            end if;
+         ----------------------------------------------------------------------
+         when MOVE_S =>
+            -- Check for new data
+            if (dataValid = '1') then
+
+               -- Check if ready to move data
+               if (v.txMaster.tValid = '0') then
+
+                  -- Send the data
+                  v.txMaster.tValid                           := '1';
+                  v.txMaster.tData(8*DATA_BYTES_G-1 downto 0) := dataValue;
+
+                  -- Set the SOF bit
+                  ssiSetUserSof(AXIS_CONFIG_C, v.txMaster, r.sof);
+
+                  -- Reset the flag
+                  v.sof := '0';
+
+                  -- Increment the counter
+                  v.wordCnt := r.wordCnt + 1;
+
+                  -- Check for End of Frame (EOF) or error bit
+                  if (r.wordCnt = r.wordSize) or (r.eofe = '1') then
+
+                     -- Set the EOF bit
+                     v.txMaster.tLast := '1';
+
+                     -- Set the EOFE bit
+                     ssiSetUserEofe(AXIS_CONFIG_C, v.txMaster, r.eofe);
+
+                     -- Next state
+                     v.state := IDLE_S;
+
+                  end if;
+
+               else
+                  -- Set the error flag
+                  v.eofe := '1';
+               end if;
+
+            end if;
+      -------------------------------------------------------
+      end case;
+
+      -- Check for change in wordSize
+      if (r.wordSize /= v.wordSize) then
+         -- Set the error flag
+         v.eofe := '1';
+      end if;
+
+      -- Synchronous Reset
+      if (RST_ASYNC_G = false and dataRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process;
+
+   axiSeq : process (dataClk, dataRst) is
+   begin
+      if (RST_ASYNC_G) and (dataRst = '1') then
+         r <= REG_INIT_C after TPD_G;
+      elsif rising_edge(dataClk) then
+         r <= rin after TPD_G;
+      end if;
+   end process;
+
+   TX_FIFO : entity surf.AxiStreamFifoV2
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         RST_ASYNC_G         => RST_ASYNC_G,
+         INT_PIPE_STAGES_G   => INT_PIPE_STAGES_G,
+         PIPE_STAGES_G       => PIPE_STAGES_G,
+         SLAVE_READY_EN_G    => true,
+         VALID_THOLD_G       => VALID_THOLD_G,
+         VALID_BURST_MODE_G  => VALID_BURST_MODE_G,
+         -- FIFO configurations
+         SYNTH_MODE_G        => SYNTH_MODE_G,
+         MEMORY_TYPE_G       => FIFO_MEMORY_TYPE_G,
+         GEN_SYNC_FIFO_G     => GEN_SYNC_FIFO_G,
+         FIFO_ADDR_WIDTH_G   => FIFO_ADDR_WIDTH_G,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXI_STREAM_CONFIG_G)
+      port map (
+         -- Slave Port
+         sAxisClk    => dataClk,
+         sAxisRst    => dataRst,
+         sAxisMaster => r.txMaster,
+         sAxisSlave  => txSlave,
+         -- Master Port
+         mAxisClk    => axisClk,
+         mAxisRst    => axisRst,
+         mAxisMaster => axisMaster,
+         mAxisSlave  => axisSlave);
+
+end mapping;

--- a/shared/rfsoc-utility/SigToAxiStream/ruckus.tcl
+++ b/shared/rfsoc-utility/SigToAxiStream/ruckus.tcl
@@ -1,0 +1,5 @@
+# Load RUCKUS library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load Source Code
+loadSource -lib axi_soc_ultra_plus_core -dir "$::DIR_PATH/rtl"

--- a/shared/rfsoc-utility/ruckus.tcl
+++ b/shared/rfsoc-utility/ruckus.tcl
@@ -4,3 +4,4 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 # Load Source Code
 loadRuckusTcl "$::DIR_PATH/AppRingBuffer"
 loadRuckusTcl "$::DIR_PATH/SigGen"
+loadRuckusTcl "$::DIR_PATH/SigToAxiStream"

--- a/shared/ruckus.tcl
+++ b/shared/ruckus.tcl
@@ -4,7 +4,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {ruckus}             {4.7.1}  ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}               {2.38.0} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}               {2.45.2} ] < 0 } {exit -1}
    if { [SubmoduleCheck {aes-stream-drivers} {5.19.0} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"


### PR DESCRIPTION
### Description
- [bug fix for latest yocto](https://github.com/slaclab/axi-soc-ultra-plus-core/commit/fcc5a9747c42522bf3e3c1e31ee1476570270874)
- [RFSoC4x2: RFDC pinout determiend from .XCI file](https://github.com/slaclab/axi-soc-ultra-plus-core/commit/95bff73b18546306ffa579b90c596558849f4101)
- [ZCU670: comment out pinout because using .XCI placement instead](https://github.com/slaclab/axi-soc-ultra-plus-core/commit/af699cdc493b748461d49367b9016163f21b164f)
- [adding rfsoc-utility/SigToAxiStream](https://github.com/slaclab/axi-soc-ultra-plus-core/pull/33/commits/95cc71691bb0b0764c91febda87cdcbc20df1d31)
- [bug fix on the symbol plot display](https://github.com/slaclab/axi-soc-ultra-plus-core/pull/33/commits/8627ce72e00928a6b9ed9711bd5c591e3c8ff10a)
- [adding MEMORY_TYPE_G & COMMON_CLK_G to AppRingBuffer.vhd](https://github.com/slaclab/axi-soc-ultra-plus-core/pull/33/commits/aef2e50869283de442ed8bfb4cfe7f97aaf6e615)
- [adding FIFO_MEMORY_TYPE_G & FIFO_COMMON_CLK_G to AppRingBuffer.vhd](https://github.com/slaclab/axi-soc-ultra-plus-core/pull/33/commits/9fd5a82eaaace2f553618ed9044404282a5255bf)
- Misc whitespace removal