### PR TITLE
Release Candidate 4.1.0

### DIFF
--- a/CreatePetalinuxProject.sh
+++ b/CreatePetalinuxProject.sh
@@ -68,6 +68,10 @@ rm -rf $name
 petalinux-create --type project --template zynqMP --name $name
 cd $name
 
+# Increase QSPI image.ub size to 128MB
+echo CONFIG_SUBSYSTEM_UBOOT_QSPI_FIT_IMAGE_OFFSET=0x4000000 >> project-spec/configs/config
+echo CONFIG_SUBSYSTEM_UBOOT_QSPI_FIT_IMAGE_SIZE=0x8000000  >> project-spec/configs/config
+
 # Importing Hardware Configuration
 petalinux-config --silentconfig --get-hw-description $xsa
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-Copyright (c) 2023, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2024, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,29 @@ Note: Make sure you power cycle the board before JTAG boot
 <!--- ######################################################## -->
 
 
+### How to Program the QSPI flash
+
+```bash
+# Go to petalinux project directory
+cd <MY_PROJECT>
+
+# Define default parameters
+default_parameter="\
+-flash_type qspi-x8-dual_parallel \
+-fsbl images/linux/zynqmp_fsbl.elf \
+-verify -cable type xilinx_tcf url TCP:127.0.0.1:3121"
+
+# Execute the commands
+program_flash -f images/linux/BOOT.BIN -offset 0x0000000 $default_parameter
+program_flash -f images/linux/boot.scr -offset 0x1f80000 $default_parameter
+program_flash -f images/linux/image.ub -offset 0x2000000 $default_parameter
+```
+
+Note: Assuming "qspi-x8-dual_parallel" for QSPI configuration
+
+<!--- ######################################################## -->
+
+
 ### How to Program the NAND flash
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,3 +182,13 @@ disconnect
 ```
 
 <!--- ######################################################## -->
+
+### How to dump all the PS diagnostic registers
+
+```bash
+cd submodule/axi-soc-ultra-plus-core
+xsct
+source xsct_debug_dump.tcl
+```
+
+<!--- ######################################################## -->

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ default_parameter="\
 # Execute the commands
 program_flash -f images/linux/BOOT.BIN -offset 0x0000000 $default_parameter
 program_flash -f images/linux/boot.scr -offset 0x3E80000 $default_parameter
-program_flash -f images/linux/image.ub -offset 0x3F80000 $default_parameter
+program_flash -f images/linux/image.ub -offset 0x4000000 $default_parameter
 ```
 
 Note: Assuming "qspi-x8-dual_parallel" for QSPI configuration

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ default_parameter="\
 
 # Execute the commands
 program_flash -f images/linux/BOOT.BIN -offset 0x0000000 $default_parameter
-program_flash -f images/linux/boot.scr -offset 0x1f80000 $default_parameter
-program_flash -f images/linux/image.ub -offset 0x2000000 $default_parameter
+program_flash -f images/linux/boot.scr -offset 0x3E80000 $default_parameter
+program_flash -f images/linux/image.ub -offset 0x3F80000 $default_parameter
 ```
 
 Note: Assuming "qspi-x8-dual_parallel" for QSPI configuration

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ cd <MY_PROJECT>
 # Define default parameters
 default_parameter="\
 -flash_type qspi-x8-dual_parallel \
--fsbl images/linux/zynqmp_fsbl.elf \
--verify -cable type xilinx_tcf url TCP:127.0.0.1:3121"
+-fsbl images/linux/zynqmp_fsbl.elf"
 
 # Execute the commands
 program_flash -f images/linux/BOOT.BIN -offset 0x0000000 $default_parameter
@@ -142,8 +141,7 @@ cd <MY_PROJECT>
 # Define default parameters
 default_parameter="\
 -flash_type nand-x8-single \
--fsbl images/linux/zynqmp_fsbl.elf \
--verify -cable type xilinx_tcf url TCP:127.0.0.1:3121"
+-fsbl images/linux/zynqmp_fsbl.elf"
 
 # Execute the commands
 program_flash -f images/linux/BOOT.BIN -offset 0x0000000 $default_parameter

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ cd <MY_PROJECT>
 # Define default parameters
 default_parameter="\
 -flash_type qspi-x8-dual_parallel \
+-blank_check -verify \
 -fsbl images/linux/zynqmp_fsbl.elf"
 
 # Execute the commands
@@ -141,6 +142,7 @@ cd <MY_PROJECT>
 # Define default parameters
 default_parameter="\
 -flash_type nand-x8-single \
+-blank_check -verify \
 -fsbl images/linux/zynqmp_fsbl.elf"
 
 # Execute the commands

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ rst -system
 disconnect
 ```
 
-#### following sequence changes to NAND mode
+#### following sequence changes to Quad-SPI (32b) mode
 ```bash
 xsct
 connect
 targets -set -nocase -filter {name =~ "*PSU*"}
 stop
-mwr  0xff5e0200 0x4100
+mwr  0xff5e0200 0x2100
 rst -system
 con
 disconnect
@@ -72,6 +72,18 @@ connect
 targets -set -nocase -filter {name =~ "*PSU*"}
 stop
 mwr  0xff5e0200 0x3100 
+rst -system
+con
+disconnect
+```
+
+#### following sequence changes to NAND mode
+```bash
+xsct
+connect
+targets -set -nocase -filter {name =~ "*PSU*"}
+stop
+mwr  0xff5e0200 0x4100
 rst -system
 con
 disconnect

--- a/hardware/XilinxZcu111/rtl/Zcu111Sc18Is602.vhd
+++ b/hardware/XilinxZcu111/rtl/Zcu111Sc18Is602.vhd
@@ -87,7 +87,8 @@ architecture rtl of Zcu111Sc18Is602 is
       regReq      => '0',
       busReq      => '0',
       endianness  => '1',               -- Big endian
-      repeatStart => '0');
+      repeatStart => '0',
+      wrDataOnRd  => '0');
 
    type StateType is (
       IDLE_S,

--- a/petalinux-apps/rogue.bb
+++ b/petalinux-apps/rogue.bb
@@ -2,8 +2,8 @@
 # This file is the rogue recipe.
 #
 
-ROGUE_VERSION = "6.1.4"
-ROGUE_MD5SUM  = "659c7f5c894f6915e2bd15f922cdab3b"
+ROGUE_VERSION = "6.2.0"
+ROGUE_MD5SUM  = "51c4eda8f7f53dbd4b66a497df9fd5a6"
 
 SUMMARY = "Recipe to build Rogue"
 HOMEPAGE ="https://github.com/slaclab/rogue"

--- a/petalinux-apps/rogue.bb
+++ b/petalinux-apps/rogue.bb
@@ -2,8 +2,8 @@
 # This file is the rogue recipe.
 #
 
-ROGUE_VERSION = "6.1.1"
-ROGUE_MD5SUM  = "f331d9f8f2bf4cfa347c482804e9e21f"
+ROGUE_VERSION = "6.1.3"
+ROGUE_MD5SUM  = "1df912b8525c01930bb869c3a2b2e7e3"
 
 SUMMARY = "Recipe to build Rogue"
 HOMEPAGE ="https://github.com/slaclab/rogue"
@@ -17,6 +17,7 @@ S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
 PROVIDES = "rogue"
 EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
 
+# Note: distutils3 is depreciated (not removed) in petalinux 2023.2 and need to switch to setuptools3 in petalinux 2024 release
 inherit cmake python3native distutils3
 
 DEPENDS += " \

--- a/python/axi_soc_ultra_plus_core/hardware/XilinxZcu208/_Hardware.py
+++ b/python/axi_soc_ultra_plus_core/hardware/XilinxZcu208/_Hardware.py
@@ -23,6 +23,12 @@ class Hardware(pr.Device):
             allowHexFileRst = False,
         ))
 
+        for i in range(2):
+            self.add(ti.Lmx2594(
+                name   = f'Lmx[{i}]',
+                offset = 0x0054_0000 + i*0x2_0000,
+            ))
+
         self.add(nxp.Sc18Is602(
             name   = 'I2cToSpi',
             offset = 0x0058_0000,
@@ -40,6 +46,12 @@ class Hardware(pr.Device):
 
     def InitClock(self, lmkConfig=None, lmxConfig=[None]):
 
+        # Check if same LMX configuration for both devices
+        if len(lmxConfig) == 1:
+            lmxCfg = [lmxConfig[0] for i in range(2)]
+        else:
+            lmxCfg = lmxConfig
+
         # Seems like 1st time after power up that need to load twice
         for x in range(2):
 
@@ -50,3 +62,10 @@ class Hardware(pr.Device):
             self.Lmk.LoadCodeLoaderHexFile(lmkConfig)
             self.Lmk.Init()
             self.Lmk.enable.set(False)
+
+            # Load the LMX configuration from the TICS Pro software HEX export
+            for i in range(2):
+                if lmxCfg[i] != None:
+                    self.Lmx[i].enable.set(True)
+                    self.Lmx[i].LoadCodeLoaderHexFile(lmxCfg[i])
+                    self.Lmx[i].enable.set(False)

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_RingBufferProcessor.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_RingBufferProcessor.py
@@ -72,7 +72,7 @@ class RingBufferProcessor(pr.DataReceiver):
 
             self.add(pr.LocalVariable(
                 name        = 'Freq',
-                description = 'Freq steps (ns)',
+                description = 'Freq steps (MHz)',
                 typeStr     = 'Float[np]',
                 value       = freqSteps,
                 hidden      = True,

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_RingBufferProcessor.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_RingBufferProcessor.py
@@ -140,25 +140,29 @@ class RingBufferProcessor(pr.DataReceiver):
         with self.root.updateGroup():
             pr.DataReceiver.process(self,frame)
 
-            # Get data from frame
-            waveformData = self.Data.value()[:].view(np.int16)
-            self.WaveformData.set(waveformData,write=True)
+            # Check frame size
+            if (frame.getPayload()//2) != self._maxSize:
+                print( f'{self.path}: Invalid frame size.  Got {frame.getPayload()//2}, expected {self._maxSize}' )
+            else:
+                # Get data from frame
+                waveformData = self.Data.value()[:].view(np.int16)
+                self.WaveformData.set(waveformData,write=True)
 
-            # Check if live display
-            if (self._liveDisplay):
+                # Check if live display
+                if (self._liveDisplay):
 
-                # Calculate the FFT
-                freq = np.fft.fft(waveformData)/float(len(waveformData))
-                freq = freq[range(len(waveformData)//2)]
+                    # Calculate the FFT
+                    freq = np.fft.fft(waveformData)/float(len(waveformData))
+                    freq = freq[range(len(waveformData)//2)]
 
-                # Prevent warning message when for divide by zero encountered in log10
-                # Checking for inf later to fix this in the display
-                np.seterr(divide = 'ignore')
+                    # Prevent warning message when for divide by zero encountered in log10
+                    # Checking for inf later to fix this in the display
+                    np.seterr(divide = 'ignore')
 
-                # Calculate the average magnitude
-                mag = 20.0*np.log10(np.abs(freq)/32767.0) # Units of dBFS
-                self._mag[self._idx] = mag
-                magnitude = self.running_mean(self._mag)
-                self.Magnitude.set(magnitude,write=True)
+                    # Calculate the average magnitude
+                    mag = 20.0*np.log10(np.abs(freq)/32767.0) # Units of dBFS
+                    self._mag[self._idx] = mag
+                    magnitude = self.running_mean(self._mag)
+                    self.Magnitude.set(magnitude,write=True)
 
-            self.NewDataReady.set(True)
+                self.NewDataReady.set(True)

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBuffer.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBuffer.vhd
@@ -48,6 +48,7 @@ entity AppRingBuffer is
       -- ADC/DAC Interface (dspClk domain)
       dspClk          : in  sl;
       dspRst          : in  sl;
+      dspAdcValid     : in  slv(NUM_ADC_CH_G-1 downto 0)              := (others => '1');
       dspAdc0         : in  slv(16*ADC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       dspAdc1         : in  slv(16*ADC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       dspAdc2         : in  slv(16*ADC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
@@ -64,6 +65,7 @@ entity AppRingBuffer is
       dspAdc13        : in  slv(16*ADC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       dspAdc14        : in  slv(16*ADC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       dspAdc15        : in  slv(16*ADC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
+      dspDacValid     : in  slv(NUM_DAC_CH_G-1 downto 0)              := (others => '1');
       dspDac0         : in  slv(16*DAC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       dspDac1         : in  slv(16*DAC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       dspDac2         : in  slv(16*DAC_SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
@@ -169,6 +171,7 @@ begin
             -- DATA Interface (dataClk domain)
             dataClk         => dspClk,
             dataRst         => dspRst,
+            dataValid       => dspAdcValid,
             data0           => dspAdc0,
             data1           => dspAdc1,
             data2           => dspAdc2,
@@ -229,6 +232,7 @@ begin
             -- DATA Interface (dataClk domain)
             dataClk         => dspClk,
             dataRst         => dspRst,
+            dataValid       => dspDacValid,
             data0           => dspDac0,
             data1           => dspDac1,
             data2           => dspDac2,

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
@@ -44,6 +44,7 @@ entity AppRingBufferEngine is
       -- DATA Interface (dataClk domain)
       dataClk         : in  sl;
       dataRst         : in  sl;
+      dataValid       : in  slv(NUM_CH_G-1 downto 0)              := (others => '1');
       data0           : in  slv(16*SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       data1           : in  slv(16*SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
       data2           : in  slv(16*SAMPLE_PER_CYCLE_G-1 downto 0) := (others => '0');
@@ -141,6 +142,7 @@ begin
          port map (
             -- Data to store in ring buffer (dataClk domain)
             dataClk         => dataClk,
+            dataValid       => dataValid(i),
             dataValue       => dataValues(i),
             extTrig         => extTrigIn,
             -- AXI-Lite interface (axilClk domain)

--- a/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
+++ b/shared/rfsoc-utility/AppRingBuffer/rtl/AppRingBufferEngine.vhd
@@ -150,7 +150,7 @@ begin
             axilReadSlave   => axilReadSlaves(i),
             axilWriteMaster => axilWriteMasters(i),
             axilWriteSlave  => axilWriteSlaves(i),
-            -- AXI-Stream Interface (axilClk domain)
+            -- AXI-Stream Interface (axisClk domain)
             axisClk         => axisClk,
             axisRst         => axisRst,
             axisMaster      => axisMasters(i),

--- a/shared/ruckus.tcl
+++ b/shared/ruckus.tcl
@@ -3,9 +3,9 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {aes-stream-drivers} {5.19.2} ] < 0 } {exit -1}
-   if { [SubmoduleCheck {ruckus}             {4.10.0} ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}               {2.45.4} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {aes-stream-drivers}  {6.1.2} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus}             {4.13.0} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}               {2.47.3} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"

--- a/xsct_debug_dump.tcl
+++ b/xsct_debug_dump.tcl
@@ -4,10 +4,10 @@ proc regdump {msg} {
 
     set value [mrd -force 0xFF5E0200]
     puts -nonewline "    BOOT_MODE_USER                  = $value"
-	
+
     set value [mrd -force 0xFF5E0204]
     puts -nonewline "    BOOT_MODE_POR                   = $value"
-	
+
     set value [mrd -force 0xFF5E0220]
     puts -nonewline "    RESET_REASON                    = $value"
 

--- a/xsct_debug_dump.tcl
+++ b/xsct_debug_dump.tcl
@@ -1,0 +1,60 @@
+proc regdump {msg} {
+    puts "======================================================================"
+    puts "==  $msg"
+
+    set value [mrd -force 0xFF5E0200]
+    puts -nonewline "    BOOT_MODE_USER                  = $value"
+	
+    set value [mrd -force 0xFF5E0204]
+    puts -nonewline "    BOOT_MODE_POR                   = $value"
+	
+    set value [mrd -force 0xFF5E0220]
+    puts -nonewline "    RESET_REASON                    = $value"
+
+    set value [mrd -force 0xFFD80100]
+    puts -nonewline "    PMU_GLOBAL.PWR_STATE            = $value"
+
+    set value [mrd -force 0xFFD8010C]
+    puts -nonewline "    PWR_SUPPLY_STATUS               = $value"
+
+    set value [mrd -force 0xFFD80528]
+    puts -nonewline "    CSU_BR_ERROR                    = $value"
+
+    set value [mrd -force 0xFFD80530]
+    puts -nonewline "    ERROR_STATUS_1                  = $value"
+
+    set value [mrd -force 0xFFD80540]
+    puts -nonewline "    ERROR_STATUS_2                  = $value"
+
+    set value [mrd -force 0xFFCA0000]
+    puts -nonewline "    csu_status                      = $value"
+
+    set value [mrd -force 0xFFCA0018]
+    puts -nonewline "    csu_ft_status                   = $value"
+
+    set value [mrd -force 0xFFCA0020]
+    puts -nonewline "    CSU_ISR                         = $value"
+
+    set value [mrd -force 0xFFCA3010]
+    puts -nonewline "    pcap_status                     = $value"
+
+    set value [mrd -force 0xFFCA5000]
+    puts -nonewline "    tamper_status                   = $value"
+
+    set value [mrd -force 0xFFCA0034]
+    puts -nonewline "    jtag_chain_status               = $value"
+
+    set value [mrd -force 0xFFCA0038]
+    puts -nonewline "    jtag_sec                        = $value"
+
+    puts [targets]
+}
+connect
+targets -set -filter {name =~ "PSU" || name =~ "PS8"}
+mwr 0xffca0038 0x1FF
+targets -set -filter {name =~ "MicroBlaze PMU"}
+exec sleep 1
+regdump "Registers Dump"
+puts [fpga -config-status]
+disconnect
+


### PR DESCRIPTION
### Description
- Updating LICENSE.txt for 2024
- In Petalinux: 
  - Override the default `CONFIG_SUBSYSTEM_UBOOT_QSPI_FIT_IMAGE_OFFSET` & `CONFIG_SUBSYSTEM_UBOOT_QSPI_FIT_IMAGE_SIZE`
- Update README.md for QPI(32b) boot 
- Added `xsct_debug_dump.tcl`, which is useful for debugging SoC via JTAG
- updated rogue.bb from distutils3 to setuptools3
- Added LMX support to ZCU208/ZCU216
- Added payload size checking in `_RingBufferProcessor.py`