### PR TITLE
Remove word 'DAC' from error message

### DIFF
--- a/petalinux-apps/pyrfdc/files/PyRFdc.cpp
+++ b/petalinux-apps/pyrfdc/files/PyRFdc.cpp
@@ -2885,7 +2885,7 @@ void PyRFdc::MtsSync() {
             }
 
         } else {
-            errMsg_ = "MtsSync(" + std::to_string(tileType_) + "): DAC Multi-Tile-Sync did not complete successfully. Error code (" + std::to_string(status) + ")\n";
+            errMsg_ = "MtsSync(" + std::to_string(tileType_) + "): Multi-Tile-Sync did not complete successfully. Error code (" + std::to_string(status) + ")\n";
         }
 
     // Else Read


### PR DESCRIPTION
This error message is also logged when ADC tile sync fails. In that case it is confusing (or just wrong) if the message contains the word 'DAC'.

Separate messages for the DAC and ADC case may also be an option so the user does not have infer what the `tileType_` number means (0 for ADC, 1 for DAC). But I am not sure if that is the desired solution here.