### PR TITLE
Use persistent sstate-cache (located outside the project directory)

### DIFF
--- a/BuildYoctoProject.sh
+++ b/BuildYoctoProject.sh
@@ -175,6 +175,13 @@ echo ""                                          >> $proj_dir/build/conf/local.c
 echo "# Custom Configurations "                  >> $proj_dir/build/conf/local.conf
 echo "hostname:pn-base-files = \"$Name\""        >> $proj_dir/build/conf/local.conf
 
+# Keep the sstate-cache in a location outside the proj_dir to make sure it is
+# not deleted when re-running the build. Use of sstate-cache allows for re-use
+# of already build components which should significantly speed up build time
+# (except for the first time).
+sstate_dir=$path
+sed -i "/^#SSTATE_DIR ?= /c\SSTATE_DIR ?= \"$sstate_dir/sstate-cache\"" $proj_dir/build/conf/local.conf
+
 ##############################################################################
 # Add the hardware specific BSP
 ##############################################################################


### PR DESCRIPTION
With the current build script we always delete the whole project directory (`firmware/build/Yocto/[target name]`)
*including the `sstate-cache` directory*, which is maybe not optimal.
`sstate-cache` can be used to reduce build time by re-using already build components.

To avoid deleting it, I thus suggest to set the `SSTATE_DIR` to a location in the build folder outside the project dir, say `firmware/build/Yocto/sstate-cache`.

This also significantly reduces the disk space required for a build as the `sstate-cache` directory is only around 10GB. A build without cache produces around 130GB of files (including cache). A build using the cache (not rebuilding anything) only produces around 13GB. As most of the files produced during build are probably no longer needed, one can delete them and only keep the cache.

A build using the cache of course is also much faster.

Initial build with no cache present however still takes a long time. There appears to be the option to use `SSTATE_MIRRORS` to point to a cache server, however I could not find a sufficiently fast, public cache server. Perhaps the user is supposed to set up his own server.  Section "use sstate cache server" [here](https://wiki.yoctoproject.org/wiki/Enable_sstate_cache) seems to indicate this. 
I tried the following addition to the build script, but communication with the server was extremely slow.
```sh
sed -i "/^BB_HASHSERVE =/c\BB_HASHSERVE = \"auto\"" $proj_dir/build/conf/local.conf
sed -i "/^BB_SIGNATURE_HANDLER =/c\BB_SIGNATURE_HANDLER = \"OEEquivHash\"" $proj_dir/build/conf/local.conf
echo "BB_HASHSERVE_UPSTREAM = \"wss://hashserv.yoctoproject.org/ws\"" >> $proj_dir/build/conf/local.conf
echo "SSTATE_MIRRORS ?= \"file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH\"" >> $proj_dir/build/conf/local.conf
```
So initial build will probably always be slow.