### PR TITLE
Do not clear terminal when running build script

### DIFF
--- a/BuildYoctoProject.sh
+++ b/BuildYoctoProject.sh
@@ -9,9 +9,6 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 
-# Clear terminal output
-echo -ne "\033c"
-
 while getopts p:n:h:x:l:d:t:r:s:f: flag
 do
     case "${flag}" in


### PR DESCRIPTION
No clear reason why terminal should be cleared, thus rather confusing behaviour.