### PR TITLE
Do not include `rogue-dev` in the Yocto images

### DIFF
--- a/shared/Yocto/zynqmp-user.conf
+++ b/shared/Yocto/zynqmp-user.conf
@@ -5,7 +5,7 @@ HDF_BASE = "file://"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS:append = " axistreamdma aximemorymap"
 
 # Add axi-soc-versal-core's recipes-apps
-IMAGE_INSTALL:append = " rogue rogue-dev"
+IMAGE_INSTALL:append = " rogue"
 IMAGE_INSTALL:append = " roguetcpbridge"
 IMAGE_INSTALL:append = " axiversiondump"
 IMAGE_INSTALL:append = " startup-app-init"


### PR DESCRIPTION
`rogue-dev` appears to somehow pull along a huge amount of dependencies inflating the generated image.
Apparently this should also have been included in the images produced by the old Petalinux build process, but inspecting build files suggests that the setting somehow ended up ignored, so the `rogue-dev` never was in the images.

I could not find any obvious problems running the tcp bridge on an image without `rogue-dev`. Also, as it appears like `rogue-dev` never was in the older Petalinux images, we are probably fine without it.