### PR TITLE
BuildYoctoProject.sh: Allow for custom local.conf entries

### DIFF
--- a/BuildYoctoProject.sh
+++ b/BuildYoctoProject.sh
@@ -315,6 +315,14 @@ then
       done
    fi
 
+   ##############################################################################
+   # Append any user-provided configuration data
+   ##############################################################################
+   if [ -f "$projTop/shared/Yocto/local.conf" ]
+   then
+      echo -e "\n#====== > $projTop/shared/Yocto/local.conf < ======#" >> "$proj_dir/build/conf/local.conf"
+      cat "$projTop/shared/Yocto/local.conf" >> "$proj_dir/build/conf/local.conf"
+   fi
 else
    # cd to project dir in preparation for build
    cd $proj_dir


### PR DESCRIPTION
This is handy to set distro-level options like preferred providers, layer priorities, etc.

`firmware/shared/Yocto/local.conf` is where the file is located