### PR TITLE
Update BuildYoctoProject script to support custom tmpdir

### DIFF
--- a/BuildYoctoProject.sh
+++ b/BuildYoctoProject.sh
@@ -329,8 +329,11 @@ fi
 
 bitbake petalinux-image-minimal
 
+# Resolve deploy directory: honour BitBake's TMPDIR override if set
+deploy_dir="${TMPDIR:-$proj_dir/build/tmp}/deploy/images/zynqmp-user"
+
 # Check if we need to manual run xilinx-bootbin
-if [ ! -f "$proj_dir/build/tmp/deploy/images/zynqmp-user/boot.bin" ]; then
+if [ ! -f "$deploy_dir/boot.bin" ]; then
   echo "boot.bin not found. Running bitbake xilinx-bootbin..."
   bitbake xilinx-bootbin
 fi
@@ -343,7 +346,7 @@ fi
 mkdir -p $proj_dir/linux
 
 # Go to deploy image dir
-cd $proj_dir/build/tmp/deploy/images/zynqmp-user
+cd $deploy_dir
 
 # Copy over the FSBL, U-boot and .bit files
 cp -rfL download-zynqmp-user.bit $proj_dir/linux/system.bit


### PR DESCRIPTION
Update BuildYoctoProject to use TMPDIR environment variable as the tmpdir path if set.  How to set TMPDIR:

```
export BB_ENV_PASSTHROUGH_ADDITIONS="TMPDIR"
export TMPDIR=<TMPDIR path>
./BuildYoctoProject.sh ...
```

Closes #87 