### PR TITLE
yocto: drop XSCT deprecation banner from shared zynqmp-user.conf

### DIFF
--- a/shared/Yocto/zynqmp-user.conf
+++ b/shared/Yocto/zynqmp-user.conf
@@ -27,6 +27,9 @@ XILINX_WITH_ESW = "xsct"
 # and the libtinfo.so.5 sanity check it bundles is already known good on the
 # build host. Drops both warnings emitted by the bbclass without touching the
 # rest of meta-xilinx-tools.
+#######################################################################################################
+# Each new PetaLinux release, we should verify that new sanity checks haven't been added to this layer.
+#######################################################################################################
 INHERIT:remove = "sanity-meta-xilinx-tools"
 
 # Increase QSPI_FIT_IMAGE_SIZE so image.ub can fit into a 192MB memory region

--- a/shared/Yocto/zynqmp-user.conf
+++ b/shared/Yocto/zynqmp-user.conf
@@ -21,6 +21,14 @@ IMAGE_FEATURES:append = " debug-tweaks"
 XILINX_XSCT_VERSION = "2025.1"
 XILINX_WITH_ESW = "xsct"
 
+# Suppress the meta-xilinx-tools deprecation banner that fires on every parse
+# while XILINX_WITH_ESW = "xsct". The Vivado .xsa -> Yocto pipeline stays on
+# XSCT (no Vitis SDTGen in this flow), so the warning is informational noise
+# and the libtinfo.so.5 sanity check it bundles is already known good on the
+# build host. Drops both warnings emitted by the bbclass without touching the
+# rest of meta-xilinx-tools.
+INHERIT:remove = "sanity-meta-xilinx-tools"
+
 # Increase QSPI_FIT_IMAGE_SIZE so image.ub can fit into a 192MB memory region
 QSPI_KERNEL_OFFSET:${MACHINE} = "0x3F00000"
 QSPI_KERNEL_SIZE:${MACHINE} = "0x1D00000"


### PR DESCRIPTION
Disable meta-xilinx-tools' sanity-meta-xilinx-tools.bbclass via INHERIT:remove. The class fires a bb.warn on every parse while XILINX_WITH_ESW = "xsct", which it remains because the SLAC build flow has no Vitis SDTGen step to feed the SDT path. The libtinfo.so.5 sanity check the bbclass also performs is already known-good on the build host.

Verified end-to-end on a RealDigitalRfSoC4x2 build (Petalinux 2025.1): zero WARNING messages, all four release artifacts produced unchanged in size (system.bit, BOOT.BIN, boot.scr, image.ub), 7211/7211 bitbake tasks sstate-hit.