### PR TITLE
Pyrfdc audit: rename DAC InterpolationFactor, fix descriptions/URL, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,12 @@ bin*
 *.bif
 *.elf
 *.dcp
+
+# AI Agents
+.vscode/
+.cursor/
+.claude/
+.planning/
+planning/
+CLAUDE.md
+

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_Rfdc.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_Rfdc.py
@@ -369,7 +369,7 @@ class Rfdc(pr.Device):
 
                 self.add(pr.RemoteVariable(
                     name         = 'IsDacEnabled',
-                    description  = 'MMethod to get all the enabled MTS ADC tiles',
+                    description  = 'Method to get all the enabled MTS DAC tiles',
                     offset       = 0x11004,
                     bitSize      = 4,
                     mode         = 'RO',

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_Rfdc.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_Rfdc.py
@@ -646,20 +646,18 @@ class Rfdc(pr.Device):
             if self.enAdcTile[i] and (self.CheckAdcTileEnabled[i].get() != 0):
                 for j in range(4):
                     self.AdcTile[i].IsADCBlockEnabled[j].get() # Update shadow variable
-                    for k in range(2):
-                        self.AdcTile[i].AdcBlock[j].BlockStatus.MixerMode.get() # Update shadow variable
-                        self.AdcTile[i].AdcBlock[j].BlockStatus.SampleRate.get() # Update shadow variable
-                        self.AdcTile[i].AdcBlock[j].IsMixerEnabled.get() # Update shadow variable
+                    self.AdcTile[i].AdcBlock[j].BlockStatus.MixerMode.get() # Update shadow variable
+                    self.AdcTile[i].AdcBlock[j].BlockStatus.SampleRate.get() # Update shadow variable
+                    self.AdcTile[i].AdcBlock[j].IsMixerEnabled.get() # Update shadow variable
 
         # Reset DAC Tiles
         for i in range(4):
             if self.enDacTile[i] and (self.CheckDacTileEnabled[i].get() != 0):
                 for j in range(4):
                     self.DacTile[i].IsDACBlockEnabled[j].get() # Update shadow variable
-                    for k in range(2):
-                        self.DacTile[i].DacBlock[j].BlockStatus.MixerMode.get() # Update shadow variable
-                        self.DacTile[i].DacBlock[j].BlockStatus.SampleRate.get() # Update shadow variable
-                        self.DacTile[i].DacBlock[j].IsMixerEnabled.get() # Update shadow variable
+                    self.DacTile[i].DacBlock[j].BlockStatus.MixerMode.get() # Update shadow variable
+                    self.DacTile[i].DacBlock[j].BlockStatus.SampleRate.get() # Update shadow variable
+                    self.DacTile[i].DacBlock[j].IsMixerEnabled.get() # Update shadow variable
 
         # Update all the remote variables after the reset
         self.readBlocks(recurse=True)

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_RfdcBlock.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_RfdcBlock.py
@@ -802,7 +802,6 @@ class RfdcBlock(pr.Device):
             ))
 
         #######################################################################################
-        # https://docs.amd.com/r/en-US/pg269-rf-data-converter/XRFdc_GetLinkCoupling (XRFdc_GetLinkCoupling API Scheduled for deprication in 2024.1)
         # https://docs.amd.com/r/en-US/pg269-rf-data-converter/XRFdc_GetCoupling
         #######################################################################################
         if isAdc or gen3:

--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_RfdcBlock.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_RfdcBlock.py
@@ -381,7 +381,7 @@ class RfdcBlock(pr.Device):
             # https://docs.amd.com/r/en-US/pg269-rf-data-converter/XRFdc_GetInterpolationFactor
             #######################################################################################
             self.add(pr.RemoteVariable(
-                name         = 'DecimationFactor',
+                name         = 'InterpolationFactor',
                 description  = 'This API function sets the interpolation factor for the requested RF-DAC and also updates the FIFO read width based on the interpolation factor',
                 offset       = 0x068,
                 bitSize      = 6,


### PR DESCRIPTION
## Summary

Audit pass over the `pyrfdc` Yocto C++ binding and the `_Rfdc.py` / `_RfdcTile.py` /
`_RfdcBlock.py` PyRogue device tree against the AMD/Xilinx PG269 RFDC bare-metal
API.

Three commits:

1. **`561a92f` cosmetic** — fix description typo and stale URL.
   - `_Rfdc.py:372` had `'MMethod to get all the enabled MTS ADC tiles'` for the
     `IsDacEnabled` bitmask: typo (`MMethod`) + wrong converter type (`ADC` instead
     of `DAC`).
   - `_RfdcBlock.py:805` had a stale `XRFdc_GetLinkCoupling` URL with a
     "Scheduled for deprication in 2024.1" note. The C++ `LinkCoupling()` handler
     in `PyRFdc.cpp:1717` already calls `XRFdc_GetCoupling()` (the active API),
     and PG269 v2.6 (2025-05-29) still documents `GetLinkCoupling` as active, so
     the deprecation projection never landed. Drop the stale line.

2. **`4eac9d3` functional** — rename DAC `DecimationFactor` → `InterpolationFactor`,
   remove dead `range(2)` loops.
   - `_RfdcBlock.py:384` — DAC blocks correctly drive the C++ `InterpolationFactor()`
     handler at `blockAddr=0x068` (`PyRFdc.cpp:3587`) which wraps
     `XRFdc_SetInterpolationFactor` / `XRFdc_GetInterpolationFactor`. The Python
     attribute name was `'DecimationFactor'`, the inverse operation. Surrounding
     URL/comment/description already correctly named the operation as
     interpolation. Rename the user-visible attribute to match. ADC blocks keep
     `DecimationFactor`.
   - `_Rfdc.py:649,659` — `UpdateIsEnabled()` wrapped three identical `.get()`
     calls in `for k in range(2):` which just runs the same three reads twice.
     Drop the loop wrapper. No semantic change.

3. **`3c5afed`** — update `.gitignore` for AI-agent / planning artifacts
   (`.vscode/`, `.cursor/`, `.claude/`, `.planning/`, `planning/`, `CLAUDE.md`).

## Address-map cross-reference

130 C++ dispatch entries in `doTransaction()` (`PyRFdc.cpp:3249-3741`) cross-checked
against 188 active Python `offset=` definitions across the three device-tree
files. Findings:

- 0 Python offsets without a C++ handler.
- 2 C++ dispatches with no Python user (intentional, both pre-existing): `0x098-0x09C → FabClkFreq()` (Python disabled at `_RfdcTile.py:653-665`, "Always returns 0.0 because ADCTile_Config[Tile_Id].FabClkFreq is never set by the driver") and `0x1B8 → DataWidth()` (Python disabled at `_RfdcBlock.py:1088-1097`).
- 30 packed-register groups verified — all are either genuine bit-packed fields with non-overlapping bitOffsets, or the same numeric offset in different address spaces (tile-only space `bit12=0` vs tile+block space `bit12=1`, which are different absolute addresses).

## XRFdc_* call correctness

Spot-checked `StartUp`, `Shutdown`, `Reset`, `MixerSettings`, `QMCSettings`,
`CoarseDelaySettings`, `IpVersion`, `LinkCoupling`, `RestartSM`, `RestartState`,
`ClockDetector`, `IPStatus`, `BlockStatus`. All match PG269 signatures (parameter
order, types, return-code handling) and Get/Set `rdTxn_` semantics. Cached config
structs (`mixerConfig_`, `qmcConfig_`, `pllConfig_`) stay consistent across Set
operations.

## Out of scope (deferred)

- `XRFdc_SetClkDistribution` / `XRFdc_GetClkDistribution` (Gen-3/DFE) is still
  TODO at `PyRFdc.h:13-14` — adding the wrapper is a non-trivial new feature
  requiring memory-map allocation and Python device-tree extension.
- C++ comment typo `deprication` → `deprecation` at `PyRFdc.cpp:1710`. Cosmetic
  only, but a C++ change requires a full Yocto rebuild — defer until the next
  C++ change wave.

## Test plan

- [x] `flake8 --count python/` returns 0
- [x] `python -m compileall -q python/` clean
- [x] CI trailing-whitespace gate (`grep -rnI '[[:blank:]]\$' --include=\*.{vhd,sh,tcl,py,xdc}`) clean
- [x] Hardware regression on a live ZCU216:
  - Pre-fix vs post-cosmetic register dump: 0 non-calibration diffs (only
    background-calibration `CAL_BLOCK_*_Coeff[*]` fluctuations, expected).
  - Pre-fix vs post-functional register dump: schema changed by exactly 32
    entries — 16 removed (`DacTile[*].DacBlock[*].DecimationFactor`) + 16 added
    (`DacTile[*].DacBlock[*].InterpolationFactor`). ADC tree unchanged. All
    non-calibration values unchanged.
  - Live read confirmed: `DacTile[0].DacBlock[0].InterpolationFactor.get()` and
    `AdcTile[0].AdcBlock[0].DecimationFactor.get()` both succeed; old DAC
    `DecimationFactor` attribute correctly gone.

## Backward compatibility

The DAC `DecimationFactor` → `InterpolationFactor` rename is a user-visible API
change. Any caller doing `DacTile[i].DacBlock[j].DecimationFactor.set(...)` will
get an `AttributeError`. No backward-compat alias is added: the old name was
misleading (DACs interpolate, ADCs decimate), and surfacing the correct name
is preferable to perpetuating the misnomer. Searched the org's
`zcu208-cryo-det`, `Simple-ZCU216-Example`, and the host code in this repo —
no callers using `DacBlock[*].DecimationFactor`.

## Notes

Filed as draft pending review of the rename's blast radius across other
consumers of `axi_soc_ultra_plus_core.rfsoc_utility`. Mark ready for review
once any downstream apps are confirmed clean.