### PR TITLE
feat: add Mixer.UpdateEventWithRestart helper for operating-point-sensitive apps

### DIFF
--- a/python/axi_soc_ultra_plus_core/rfsoc_utility/_RfdcBlock.py
+++ b/python/axi_soc_ultra_plus_core/rfsoc_utility/_RfdcBlock.py
@@ -250,6 +250,31 @@ class RfdcBlock(pr.Device):
                     function     = lambda cmd: cmd.set(1),
                 ))
 
+                #######################################################################################
+                # Heavy-update path: UpdateEvent + tile RestartSM. Triggers the IP power-on state
+                # machine which re-runs Converter_Calibration[0..2] when the parent tile's
+                # RestartStateStart is set to a step <= Clock_Configuration[0]. Matches the surf
+                # v1.7.0 legacy RfBlock NCO-update pattern. Use only when the converter trim is
+                # operating-point-sensitive (e.g. cryo-detectors, qubit readout). Plain
+                # UpdateEvent() is ~100x faster and sufficient for most consumers.
+                # Pre-condition: set parent tile's RestartStateStart (e.g. to 'Clock_Configuration[0]')
+                # before invoking. Post-condition: caller may want to poll the parent tile's
+                # CurrentState until 'Done' (15) before issuing dependent commands.
+                #######################################################################################
+                self.add(pr.LocalCommand(
+                    name        = 'UpdateEventWithRestart',
+                    description = 'Commit pending Mixer settings (UpdateEvent) AND trigger the parent tile RestartSM. See class comment for pre/post conditions.',
+                    function    = self._UpdateEventWithRestart,
+                ))
+
+            def _UpdateEventWithRestart(self):
+                # Step 1: flush the cached mixer config to HW via the standard event mechanism.
+                self.UpdateEvent()
+                # Step 2: trigger the parent tile's RestartSM. With RestartStateStart at
+                # Clock_Configuration[0], the IPSM window 6..15 includes Converter_Calibration.
+                # parent chain: Mixer -> RfdcBlock -> RfdcTile.
+                self.parent.parent.RestartSM()
+
         self.add(pr.LinkVariable(
             name         = 'IsMixerEnabled',
             mode         = 'RO',


### PR DESCRIPTION
## Summary

Adds a single additive `pr.LocalCommand` on the `Mixer` nested device inside
`RfdcBlock` (both ADC and DAC paths). When invoked, it does:

1. `Mixer.UpdateEvent()` — the existing standard mechanism
   (`XRFdc_SetMixerSettings` + `XRFdc_UpdateEvent(XRFDC_EVENT_MIXER)`).
2. `parent_tile.RestartSM()` — triggers the IP power-on state machine.

When the parent tile's `RestartStateStart` is pre-set to a step
`<= Clock_Configuration[0]`, the RestartSM-triggered IPSM window includes
`Converter_Calibration[0..2]`, so the converter trim is refreshed for the
new operating point.

## Context

Follow-up to PR #93 (the pyrfdc audit) and the cryo-det v3.0.1 fallback
investigation (`slaclab/zcu208-cryo-det#12`). The bare-metal
`XRFdc_UpdateEvent(XRFDC_EVENT_MIXER)` path is correct per PG269 and remains
the default. Some applications (cryo-detectors, qubit readout) are sensitive
to operating-point-specific calibration trim and need the converter
re-calibrated after every NCO change, which only happens on a tile RestartSM
that includes the `Converter_Calibration[0..2]` IPSM steps.

This command is the "thin Python helper" suggested in
`CRYO-DET-INVESTIGATION.md` — it composes existing primitives
(`Mixer.UpdateEvent`, `tile.RestartSM`) into a single button so apps that
need the heavy path don't have to implement the pattern themselves.

## Pre/post conditions

**Pre-condition (caller's responsibility):** set the parent tile's
`RestartStateStart` — typically once during init, matching the legacy
`_RfDataConverter.Init(dynamicNco=True)` pattern:

```python
tile = root.Rfdc.AdcTile[i]
tile.RestartStateStart.setDisp('Clock_Configuration[0]')
tile.RestartStateEnd.setDisp('Done')
```

If `RestartStateStart` is left at default (0 = `Device_Power-up_and_Configuration[0]`),
RestartSM still works but performs a full power-up — much heavier than
necessary and fine but slower.

**Post-condition (caller's responsibility):** the IPSM run is asynchronous;
poll `tile.CurrentState` until `'Done'` (15) before issuing dependent
commands if strict serialization is required:

```python
block.Mixer.UpdateEventWithRestart()
while tile.CurrentState.get() != 15:
    time.sleep(0.05)
```

The helper does not include a wait loop — that's intentional, to match
the fire-and-forget semantics of the surf-legacy NCO-update path and to
keep the helper "thin". Adding a poll inside the command would also
serialize over TCP for every call, which is unwanted for batch updates.

## Defaults unchanged

- No change to `Mixer.UpdateEvent` (the fast event-only path stays
  exactly as it was).
- No change to any other variable, command, or device-tree topology.
- `RestartStateStart` defaults are untouched — caller must opt in.

## Test plan

- [x] `flake8 --count python/` returns 0
- [x] `python -m compileall -q python/` clean
- [x] CI trailing-whitespace gate clean
- [x] Live ZCU216 (`10.0.0.12`) verification:
  - `UpdateEventWithRestart` is exposed on `AdcTile[*].AdcBlock[*].Mixer`
    and `DacTile[*].DacBlock[*].Mixer` (4 commands per Mixer device,
    alongside `ReadDevice`, `WriteDevice`, `UpdateEvent`).
  - `Mixer.parent.parent` resolves to the correct `RfdcTile`.
  - Invocation completes without raising; underlying register writes
    (Mixer 0x03C, parent-tile 0x800) are issued.

## Backward compatibility

Purely additive. Any caller that wasn't using `UpdateEventWithRestart`
sees no change. Adding a `LocalCommand` to a pyrogue Device cannot collide
with existing variable/command names within that device — this name is
new on `Mixer`.

## Notes

Filed as draft pending sanity check on the pre/post-condition wording in
the in-tree comment block (`_RfdcBlock.py:253-262`). Ready for review
after the description is sign-off-able.