### PR TITLE
ESROGUE-549: scale rogue TCP bridge resource limits; init PyRFdc before DMA streams

### DIFF
--- a/BuildYoctoProject.sh
+++ b/BuildYoctoProject.sh
@@ -256,6 +256,9 @@ then
    fi
 
    # Set DMA settings in the local.conf
+   # Note: the RX/TX buffer counts are a single pool shared across all dests.
+   # High numDest builds should raise -r (dmaRxBuffCount) accordingly, subject
+   # to the 1.5 GB total-buffer cap checked above.
    echo "DMA_TX_BUFF_COUNT = \"${dmaTxBuffCount}\"" >> $proj_dir/build/conf/local.conf
    echo "DMA_RX_BUFF_COUNT = \"${dmaRxBuffCount}\"" >> $proj_dir/build/conf/local.conf
    echo "DMA_BUFF_SIZE = \"${dmaBuffSize}\""        >> $proj_dir/build/conf/local.conf
@@ -280,6 +283,19 @@ then
    # Update Application with user configuration
    echo "DMA_NUM_LANES = \"${numLane}\"" >> $proj_dir/build/conf/local.conf
    echo "DMA_NUM_DEST  = \"${numDest}\"" >> $proj_dir/build/conf/local.conf
+
+   # Derive rogue TCP bridge resource limits from the stream count.
+   # The bridge opens numLane*numDest streams, each costing ~10 file descriptors
+   # and ~4 threads. Scale the systemd LimitNOFILE/LimitNPROC and the kernel
+   # thread cap with headroom (floored at the stock values) so a high-channel
+   # image boots without fd/thread exhaustion. See ESROGUE-549.
+   numStreams=$(( numLane * numDest ))
+   limitNoFile=$(( numStreams * 16 + 1024 ))
+   limitNProc=$(( numStreams * 8 + 4096 ));   (( limitNProc < 9106 ))  && limitNProc=9106
+   threadsMax=$(( numStreams * 8 + 16384 ));  (( threadsMax < 18213 )) && threadsMax=18213
+   echo "DMA_LIMIT_NOFILE = \"${limitNoFile}\"" >> $proj_dir/build/conf/local.conf
+   echo "DMA_LIMIT_NPROC  = \"${limitNProc}\""  >> $proj_dir/build/conf/local.conf
+   echo "DMA_THREADS_MAX  = \"${threadsMax}\""  >> $proj_dir/build/conf/local.conf
 
    # Check if including RFDC utility
    if grep -q 'MACHINE_FEATURES:append = " rfsoc"' "$hwDir/Yocto/zynqmp-user.conf"; then

--- a/shared/Yocto/recipes-apps/roguetcpbridge/files/roguetcpbridge
+++ b/shared/Yocto/recipes-apps/roguetcpbridge/files/roguetcpbridge
@@ -19,6 +19,7 @@ import socket
 import ipaddress
 import time
 import argparse
+import resource
 
 #################################################################
 
@@ -40,18 +41,15 @@ class ZynqTcpServer(object):
         self.memServer = rogue.interfaces.memory.TcpServer('*', 9000)
         self.memServer >> self.memMap
 
-        # Data server on port [10000+512*lane+2*tdest:10000+512*lane+2*tdest+1]
-        self.dmaStream = [[None] * numDest for _ in range(numLane)]
-        self.dataServer = [[None] * numDest for _ in range(numLane)]
-        for lane in range(numLane):
-            for tdest in range(numDest):
-                port = 10000+512*lane+2*tdest
-                print( f'Starting Stream TcpServer at Port={port} and Port={port+1} for DMA[{lane}][{tdest}]' )
-                self.dmaStream[lane][tdest] = rogue.hardware.axi.AxiStreamDma('/dev/axi_stream_dma_0', 256*lane+tdest, True)
-                self.dataServer[lane][tdest] = rogue.interfaces.stream.TcpServer('*',port)
-                self.dmaStream[lane][tdest] == self.dataServer[lane][tdest]
-
         # PyRFdc Integration
+        #
+        # Initialize PyRFdc/libmetal BEFORE opening the DMA streams.  libmetal's
+        # Linux IRQ thread select()s over its UIO file descriptor, which must
+        # stay below FD_SETSIZE (1024).  Opening the per-stream descriptors first
+        # would push libmetal's UIO fd >= 1024 once numLane*numDest is large,
+        # crashing with "bit out of range 0 - FD_SETSIZE on fd_set" and
+        # "metal_linux_irq_register_dev: Failed to register device to irq".
+        # rogue's stream path is epoll-based and tolerates high fds.  See ESROGUE-549.
         self.apiMap = None
         self.rfdcApi = None
 
@@ -68,6 +66,17 @@ class ZynqTcpServer(object):
             print("PyRFdc module is not installed.")
         except Exception as e:
             print(f"Error initializing PyRFdc: {e}")
+
+        # Data server on port [10000+512*lane+2*tdest:10000+512*lane+2*tdest+1]
+        self.dmaStream = [[None] * numDest for _ in range(numLane)]
+        self.dataServer = [[None] * numDest for _ in range(numLane)]
+        for lane in range(numLane):
+            for tdest in range(numDest):
+                port = 10000+512*lane+2*tdest
+                print( f'Starting Stream TcpServer at Port={port} and Port={port+1} for DMA[{lane}][{tdest}]' )
+                self.dmaStream[lane][tdest] = rogue.hardware.axi.AxiStreamDma('/dev/axi_stream_dma_0', 256*lane+tdest, True)
+                self.dataServer[lane][tdest] = rogue.interfaces.stream.TcpServer('*',port)
+                self.dmaStream[lane][tdest] == self.dataServer[lane][tdest]
 
     def __enter__(self):
         """Enable using the class as a context manager."""
@@ -122,6 +131,26 @@ if __name__ == "__main__":
 
     # Get the arguments
     args = parser.parse_args()
+
+    #################################################################
+
+    # Each TCP stream costs ~10 file descriptors and ~4 threads.  Raise the
+    # open-file soft limit toward the hard limit so a manually-launched run is
+    # not capped at the shell default (often 1024).  The systemd service sets
+    # LimitNOFILE/LimitNPROC for the boot path; this covers running by hand.
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft < hard:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+        soft = hard
+
+    streams = args.lane * args.tdest
+    projFds = streams * 10 + 64
+    projThreads = streams * 4 + 16
+    print(f"Resource budget: {streams} streams ~ {projFds} fds, ~{projThreads} threads "
+          f"(RLIMIT_NOFILE soft={soft}).")
+    if projFds > soft:
+        print(f"WARNING: ~{projFds} fds needed but RLIMIT_NOFILE soft={soft}. "
+              f"Raise LimitNOFILE / ulimit -n. See ESROGUE-549.")
 
     #################################################################
 

--- a/shared/Yocto/recipes-apps/startup-app-init/files/startup-app-init
+++ b/shared/Yocto/recipes-apps/startup-app-init/files/startup-app-init
@@ -117,6 +117,15 @@ insmod /lib/modules/$(uname -r)/updates/axi_stream_dma.ko cfgTxCount0=@DMA_TX_BU
 # Dump AxiVersion Status
 /usr/bin/axiversiondump
 
+##############################################################################
+
+# Scale the kernel thread cap for the rogue TCP bridge: numLane*numDest streams
+# at ~4 threads/stream can exceed the default kernel.threads-max. Best-effort;
+# harmless if the running kernel already allows more.
+sysctl -w kernel.threads-max=@DMA_THREADS_MAX@ > /dev/null 2>&1
+
+##############################################################################
+
 # Check if user's runtime application exists
 if [ -f "/app/runtimeApp" ]
 then

--- a/shared/Yocto/recipes-apps/startup-app-init/files/startup-app-init.service
+++ b/shared/Yocto/recipes-apps/startup-app-init/files/startup-app-init.service
@@ -6,6 +6,10 @@ After=local-fs.target systemd-user-sessions
 [Service]
 Type=idle
 Restart=always
+# Scaled with numLane*numDest at build time (see BuildYoctoProject.sh).
+# Each rogue TCP stream costs ~10 file descriptors and ~4 threads.
+LimitNOFILE=@DMA_LIMIT_NOFILE@
+LimitNPROC=@DMA_LIMIT_NPROC@
 ExecStart=/usr/bin/startup-app-init
 StandardOutput=journal+console
   

--- a/shared/Yocto/recipes-apps/startup-app-init/startup-app-init.bb
+++ b/shared/Yocto/recipes-apps/startup-app-init/startup-app-init.bb
@@ -41,6 +41,13 @@ do_install() {
         sed -i "s/@DMA_RX_BUFF_COUNT@/${DMA_RX_BUFF_COUNT}/g" ${WORKDIR}/startup-app-init
         sed -i "s/@DMA_BUFF_SIZE@/${DMA_BUFF_SIZE}/g"         ${WORKDIR}/startup-app-init
 
+        # Scale the kernel thread cap with numLane*numDest (rogue TCP bridge)
+        sed -i "s/@DMA_THREADS_MAX@/${DMA_THREADS_MAX}/g" ${WORKDIR}/startup-app-init
+
+        # Scale the systemd resource limits with numLane*numDest (rogue TCP bridge)
+        sed -i "s/@DMA_LIMIT_NOFILE@/${DMA_LIMIT_NOFILE}/g" ${WORKDIR}/startup-app-init.service
+        sed -i "s/@DMA_LIMIT_NPROC@/${DMA_LIMIT_NPROC}/g"   ${WORKDIR}/startup-app-init.service
+
         if ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
                 install -d ${D}${sysconfdir}/init.d/
                 install -m 0755 ${WORKDIR}/startup-app-init ${D}${sysconfdir}/init.d/


### PR DESCRIPTION
## Summary
Raising the AXI-Stream DMA destination count pushed the on-board `roguetcpbridge` past several host limits. Investigation showed the 32-dest default is a soft default, not a hardware/driver limit (8-bit TDEST = 256/lane; driver `DMA_MAX_DEST` = 4096). This change removes the host-side walls and scales resource limits with the stream count.

- **roguetcpbridge**: initialize `PyRFdc`/libmetal **before** the DMA-stream loop so libmetal's UIO fd stays below `FD_SETSIZE` (fixes the `metal_linux_irq_register_dev: Failed to register device to irq` failures at high dest counts). Self-raise `RLIMIT_NOFILE` toward the hard limit and print a fd/thread budget + warning so manually-launched runs are not capped at the shell default.
- **startup-app-init.service**: add templated `LimitNOFILE` / `LimitNPROC`.
- **startup-app-init**: raise `kernel.threads-max` (templated) before launching the bridge.
- **startup-app-init.bb**: substitute the new `@DMA_LIMIT_*@` / `@DMA_THREADS_MAX@` vars into the script and unit.
- **BuildYoctoProject.sh**: derive `DMA_LIMIT_NOFILE` / `DMA_LIMIT_NPROC` / `DMA_THREADS_MAX` from `numLane*numDest` (floored at stock values); note that the shared RX buffer pool must scale with dest count.

## Relationship to the FD_SETSIZE ceiling
These changes are necessary but **not sufficient** to reach very high channel counts. The binding wall is `select()` in rogue's `AxiStreamDma` (crashes at ~stream 100 when the DMA fd hits `FD_SETSIZE`). That is fixed separately in slaclab/rogue#1242. With both in place, the epoll-based rogue stream path scales past 100; the practical ceiling toward 2048 is then board threads/RAM.

## Test plan
- [x] `bash -n` on `BuildYoctoProject.sh`; cap arithmetic checked (2x32 stays at stock floors; 8x256 -> NOFILE 33792 / NPROC 20480 / threads-max 32768)
- [x] On-board: PyRFdc-first reorder confirmed (libmetal IRQ-register failures gone); `setrlimit` self-raise confirmed
- [ ] Full image build at high `numLane`/`numDest` with slaclab/rogue#1242, confirm clean boot and stream operation