### PR TITLE
Release Candidate 6.4.1

### DIFF
--- a/python/axi_soc_ultra_plus_core/hardware/SlacRfmcCarrier/_Hardware.py
+++ b/python/axi_soc_ultra_plus_core/hardware/SlacRfmcCarrier/_Hardware.py
@@ -32,8 +32,9 @@ class Hardware(pr.Device):
         super()._start()
 
         # Configure the LMK for 4-wire SPI
-        self.Lmk.LmkReg_0x0000.set(value=0x10) # 4-wire SPI
-        self.Lmk.LmkReg_0x014A.set(value=0x33) # RESET/GPO = SPI readback
+        self.Lmk.LmkReg_0x0000.set(value=0x90,verify=False) # 4-wire SPI + RESET
+        self.Lmk.LmkReg_0x0000.set(value=0x10,verify=False) # 4-wire SPI
+        self.Lmk.LmkReg_0x014A.set(value=0x33,verify=False) # RESET/GPO = SPI readback
 
     def InitClock(self, lmkConfig=None, lmxConfig=[None]):
 

--- a/shared/Yocto/recipes-apps/axiversiondump/files/axiversiondump
+++ b/shared/Yocto/recipes-apps/axiversiondump/files/axiversiondump
@@ -242,6 +242,7 @@ if __name__ == "__main__":
                     0x00_00_00_07: 'XilinxZcu111',
                     0x00_00_00_08: 'XilinxZcu670',
                     0x00_00_00_09: 'XilinxZcu102',
+                    0x00_00_00_0A: 'SlacRfmcCarrier',
                 },
             ))
 

--- a/shared/Yocto/recipes-apps/rogue/rogue.bb
+++ b/shared/Yocto/recipes-apps/rogue/rogue.bb
@@ -2,8 +2,8 @@
 # rogue recipe for Yocto
 #
 
-ROGUE_VERSION = "6.12.0"
-ROGUE_MD5SUM  = "f70be9599efe78407c95be2e016f2397"
+ROGUE_VERSION = "6.14.1"
+ROGUE_MD5SUM  = "a62999e4a36f1391c425a171bdc847d9"
 
 SUMMARY = "Recipe to build Rogue"
 HOMEPAGE ="https://github.com/slaclab/rogue"
@@ -16,7 +16,7 @@ INSANE_SKIP += "src-uri-bad"
 
 S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
 PROVIDES = "rogue"
-EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION} -DNO_ROCEV2=1"
+EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DNO_ROCEV2=1 -DROGUE_SKIP_PIP_INSTALL=1 -DROGUE_VERSION=v${ROGUE_VERSION}"
 
 inherit cmake python3native setuptools3
 

--- a/shared/Yocto/recipes-apps/rogue/rogue.bb
+++ b/shared/Yocto/recipes-apps/rogue/rogue.bb
@@ -16,7 +16,7 @@ INSANE_SKIP += "src-uri-bad"
 
 S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
 PROVIDES = "rogue"
-EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
+EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION} -DNO_ROCEV2=1"
 
 inherit cmake python3native setuptools3
 


### PR DESCRIPTION
### Description
- [adding SlacRfmcCarrier to axiversiondump](https://github.com/slaclab/axi-soc-ultra-plus-core/commit/3cdeae1f4842b53a16abc2b8d3f9255cb1f31036)
- [python/axi_soc_ultra_plus_core/hardware/SlacRfmcCarrier/_Hardware.py: Adding LMK reset at start()](https://github.com/slaclab/axi-soc-ultra-plus-core/commit/36743fe101e415df29a68bfc9ac81abb10b72781)
- [upgrading rogue yocto to v6.14.1](https://github.com/slaclab/axi-soc-ultra-plus-core/commit/6a112c94d689a15ce75cf1a611150861fb704ba1)