### PR TITLE
feat(netboot)!: accept .bit for the TFTP PL bitstream, rename system.bit.bin to system.bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ bin*
 # Sphinx build output
 docs/_build/
 .venv-docs/
+
+# AI Agents
+.vscode/
+.cursor/
+.claude/
+.planning/
+planning/
+CLAUDE.md
+

--- a/docs/how-to/tftp_network_boot.rst
+++ b/docs/how-to/tftp_network_boot.rst
@@ -32,13 +32,27 @@ server address) being set, explicitly or via DHCP.
 On boards built **tftp-only** for diskless (no-SD) operation, U-Boot
 also fetches the **PL bitstream** over TFTP and programs it with
 ``fpga load`` before booting the kernel, so the PL can be updated
-server-side without reflashing. It tries a per-MAC file
-(``system.bit.bin.<mac>``, the MAC dash-separated and lowercased, e.g.
-``system.bit.bin.fc-c2-3d-5a-9a-08``) first, then a generic
-``system.bit.bin``. (U-Boot's ``tftpboot`` treats a ``:`` in a filename
-as a ``hostIP:file`` separator, so the env uses ``setexpr gsub`` to
-rewrite ``${ethaddr}``'s colons to dashes before the fetch.) This step
-is **mandatory** in ``tftp-only`` mode:
+server-side without reflashing. It probes four filenames, most- to
+least-specific, preferring the Vivado ``.bit`` at each level:
+
+.. code-block:: text
+
+   system.bit.<mac>       (e.g. system.bit.fc-c2-3d-5a-9a-08)
+   system.bin.<mac>
+   system.bit
+   system.bin
+
+The MAC is dash-separated and lowercased. (U-Boot's ``tftpboot`` treats
+a ``:`` in a filename as a ``hostIP:file`` separator, so the env uses
+``setexpr gsub`` to rewrite ``${ethaddr}``'s colons to dashes before the
+fetch.) A miss costs one immediate TFTP "not found" reply rather than a
+timeout, so the extra probes are effectively free — **provided the server
+is reachable**. If nothing answers at all, each probe instead waits its
+full request timeout; see **Troubleshooting**.
+
+``fpga load`` accepts **either** a Vivado ``.bit`` or a bootgen-produced
+raw ``.bin`` — see :ref:`bitstream formats <tftp-bitstream-formats>`
+below. This step is **mandatory** in ``tftp-only`` mode:
 if the bitstream fetch or ``fpga load`` fails, netboot aborts before the
 kernel boots, so a net kernel never runs over an unprogrammed or stale
 PL. A ``fallback`` build does **not** fetch a bitstream in U-Boot — its
@@ -147,26 +161,38 @@ Steps
    the shared ``default`` config or reflashing that board's U-Boot.
 
    For a **tftp-only** (diskless) board, also stage the PL bitstream so
-   U-Boot can fetch and ``fpga load`` it (see **How It Works**). Add
-   ``-B`` to stage the generic ``system.bit.bin``, and ``-M <mac>``
-   (repeatable) to stage per-MAC copies ``system.bit.bin.<mac>``:
+   U-Boot can fetch and ``fpga load`` it (see **How It Works**).
+
+   Add ``-B`` to stage the bitstream, and ``-M <mac>`` (repeatable) for
+   per-board copies:
 
    .. code-block:: bash
 
       scripts/provision_tftp_host.sh -b RealDigitalRfSoC4x2 -B -M fc:c2:3d:5a:9a:08
 
-   The build produces ``linux/system.bit`` (a Vivado ``.bit`` with a
-   header) next to ``image.ub``; U-Boot's ``fpga load`` needs the raw PL
-   configuration ``.bin``, so ``-B`` converts it with ``bootgen``
-   (``bootgen -arch zynqmp -image <bif> -process_bitstream bin``). Source
-   your Vitis/Vivado ``settings64.sh`` first so ``bootgen`` is on
-   ``PATH`` — the script exits with a clear message if it is not. The MAC
-   in ``-M`` may be given with colons or dashes; it is stored
+   ``-B`` copies ``linux/system.bit`` across unconverted. That needs no
+   Vitis environment, and it is the first name ``loadpl_net`` probes.
+   Use ``-F bin`` instead to convert with ``bootgen``
+   (``bootgen -arch zynqmp -image <bif> -process_bitstream bin``); that
+   requires sourcing your Vitis/Vivado ``settings64.sh`` first to put
+   ``bootgen`` on ``PATH``, and the script exits with a clear message if it
+   is not there. ``-F`` implies ``-B``.
+
+   The MAC in ``-M`` may be given with colons or dashes; it is stored
    **dash-separated and lowercased** (e.g.
-   ``system.bit.bin.fc-c2-3d-5a-9a-08``) to match what the board's
+   ``system.bit.fc-c2-3d-5a-9a-08``) to match what the board's
    ``loadpl_net`` requests (it rewrites ``${ethaddr}``'s colons to dashes
    with ``setexpr``). ``fallback``-mode servers do not need any of this —
-   omit ``-B``/``-M`` and only ``image.ub`` and the PXE config are staged.
+   omit ``-B``/``-F``/``-M`` and only ``image.ub`` and the PXE config are
+   staged.
+
+   .. note::
+
+      The formats are staged exclusively: whichever you pick, the other's
+      names are removed, because a ``.bit`` and a ``.bin`` cannot both be
+      useful at once. See
+      :ref:`bitstream formats <tftp-bitstream-formats>` for why, and for
+      the substantial load-time difference between them.
 
    The server is **TFTP-only** (``dnsmasq`` runs with DNS and DHCP
    disabled), so it is safe to run alongside an existing site DHCP
@@ -215,14 +241,33 @@ Steps
           at the ``ZynqMP>`` prompt; the SD image is never consulted.
 
    ``fallback`` is the default, so it is applied even when ``-m`` is
-   omitted. The two modes produce byte-distinct ``BOOT.BIN`` images and
-   embed distinct login-banner hostnames (see **Verification** below),
-   so you can always tell which mode a board is actually running.
+   omitted. The two modes produce byte-distinct ``BOOT.BIN`` images. To
+   read a board's mode straight out of the artifact — no board required —
+   grep the ``bootcmd`` that was baked into it:
+
+   .. code-block:: bash
+
+      strings -a BOOT.BIN | grep -a '^bootcmd='
+
+   .. code-block:: text
+
+      bootcmd=run netboot; run sdboot                                    <- fallback
+      bootcmd=run netboot; echo TFTP-only build: not falling back to SD  <- tftp-only
+
+   That works on a freshly built image or on the SD card's copy at
+   ``/boot/BOOT.BIN``, and unlike a checksum it does not go stale between
+   rebuilds. Observing the TFTP-failure behavior distinguishes them too.
+   The login-banner hostname is **not** a mode indicator: it comes from the
+   target name via ``hostname:pn-base-files`` and is identical in both modes
+   (see **Verification** below).
 
    The mode also decides where the PL bitstream comes from. A
    ``tftp-only`` build additionally requires the bitstream to be staged
-   on the TFTP server (Step 1, ``-B``/``-M``) and will **halt** rather
-   than boot if it is missing. A ``fallback`` build ignores any staged
+   on the TFTP server (Step 1, ``-B``/``-F``/``-M``) and will **halt** rather
+   than boot if it is missing. It also requires ``/boot/system.bit`` to be
+   **absent** on the board: ``startup-app-init`` re-programs the PL from
+   that file whenever it exists, overriding whatever U-Boot just fetched.
+   A ``fallback`` build ignores any staged
    bitstream and programs the PL from the SD card's ``system.bit`` after
    Linux boots, exactly as a normal SD boot does.
 
@@ -332,10 +377,13 @@ Steps
 
       dhcp
       setenv serverip 10.0.0.1
-      tftpboot 0x10000000 system.bit.bin
+      tftpboot 0x10000000 system.bit
       fpga load 0 0x10000000 ${filesize}
       tftpboot 0x10000000 image.ub
       bootm 0x10000000
+
+   Substitute ``system.bin`` for ``system.bit`` if that is what you
+   staged — ``fpga load`` handles both identically.
 
    If your network has no DHCP server, set a static IP instead (keep
    it volatile — do not ``saveenv`` — so a plain ``reset`` restores the
@@ -363,13 +411,19 @@ A successful TFTP fetch reports the size of the FIT image (roughly
 
 .. code-block:: text
 
-   Bytes transferred = 116833531
+   Bytes transferred = 116835243
 
 On a ``tftp-only`` build, the bitstream fetch and ``fpga load`` run
-first — a successful load prints its own ``Bytes transferred`` line for
-``system.bit.bin`` followed by no error from ``fpga load``. Once Linux
-is up, ``startup-app-init`` confirms the PL is programmed before it
-loads the DMA drivers:
+first — a successful load prints a ``Filename`` line naming whichever of
+the four probed names hit, its own ``Bytes transferred`` line, and no
+error from ``fpga load``. A ``.bit`` transfers 222 bytes more than the
+equivalent ``.bin`` (the Vivado header); both program the same PL
+configuration. ``fpga load`` prints nothing at all on success, so the only
+sign it ran is the next command appearing — after roughly 16 s for a
+``.bit``, or a fraction of a second for a ``.bin``. A long silent pause
+directly after the bitstream's ``Bytes transferred`` line is therefore
+expected, not a hang. Once Linux is up, ``startup-app-init`` confirms the
+PL is programmed before it loads the DMA drivers:
 
 .. code-block:: text
 
@@ -389,10 +443,10 @@ The banner hostname comes from the project name of the built image
 (``SimpleRfSoc4x2Example`` here, set via ``hostname:pn-base-files``),
 not from the ``hardware`` directory name ``RealDigitalRfSoC4x2`` used
 in Step 1. It is the same for **both** boot modes, so it does not tell
-you which mode's ``BOOT.BIN`` is running -- distinguish the modes by the
-``BOOT.BIN`` md5, or by the TFTP-failure behavior (a ``fallback`` build
-SD-boots; a ``tftp-only`` build halts). Finally, confirm the board is
-reachable over the network:
+you which mode's ``BOOT.BIN`` is running -- distinguish the modes with the
+``strings -a BOOT.BIN | grep -a '^bootcmd='`` check from Step 2, or by the
+TFTP-failure behavior (a ``fallback`` build SD-boots; a ``tftp-only`` build
+halts). Finally, confirm the board is reachable over the network:
 
 .. code-block:: bash
 
@@ -422,31 +476,48 @@ Troubleshooting
      - Confirm ``/tftpboot/pxelinux.cfg/default`` exists and fetch it
        back from the host with the same TFTP check as Step 1
        (``curl -sf tftp://10.0.0.1/pxelinux.cfg/default``)
-   * - ``netboot`` takes ~2 minutes to fail (repeated ``TFTP error: -1
-       (Request timeout)`` with no ``ICMP`` lines) before the SD
-       fallback or halt runs
-     - A silent TFTP black hole -- packets dropped rather than refused
-       (e.g. a ``DROP`` firewall rule). Each of ``pxe get``'s config-name
-       probes waits its full request timeout with no ICMP to
-       short-circuit it (~110 s total)
-     - Expected under a silent drop. A *port-closed* host (TFTP daemon
-       stopped) instead fails in ~6 s because ICMP destination-unreachable
-       aborts each probe; restore TFTP reachability to get the fast path
-       back
+   * - ``netboot`` takes 1-2 minutes to fail (repeated ``TFTP error: -1
+       (Request timeout)``) before the SD fallback or halt runs
+     - No TFTP server is answering. ``netboot`` is PXE-first, so
+       ``pxe get`` walks 13 ``pxelinux.cfg`` names before the direct FIT
+       fetch, and each of those 14 attempts waits its **full** request
+       timeout (~6 s) when nothing replies: ~85 s with the daemon stopped,
+       ~110 s under a silent ``DROP`` firewall rule
+     - Expected when TFTP is unreachable, and **not** a hang. ICMP
+       ``destination unreachable`` does *not* shorten it -- a stopped
+       daemon does emit it, and each attempt still times out anyway, so
+       the presence or absence of ICMP lines does not distinguish the two
+       cases. Restore TFTP reachability: once the server answers, a
+       missing file draws an immediate ``TFTP error: 256`` refusal and the
+       whole 14-name walk costs almost nothing
    * - ``TFTP-only build: not falling back to SD`` followed by a halt
        at a bare ``ZynqMP>`` prompt, no kernel banner
      - Expected behavior: a ``tftp-only`` build halts by design when
        TFTP fails, instead of silently falling back to an SD image
      - Bring the TFTP host back up and run ``reset``, or reflash the
        board with a ``fallback`` build's ``BOOT.BIN``
-   * - ``tftp-only`` netboot halts after a failed ``system.bit.bin``
-       fetch, before any kernel fetch
-     - The PL bitstream is not staged on the server; the mandatory
-       ``loadpl_net`` step aborts netboot (never boots a net kernel over
-       an unprogrammed PL)
-     - Stage it with ``-B`` (and ``-M`` for a per-MAC copy) in Step 1,
-       and confirm ``curl -sf tftp://10.0.0.1/system.bit.bin`` fetches
-       it back from the host
+   * - ``tftp-only`` netboot halts after all four bitstream fetches fail,
+       before any kernel fetch
+     - The PL bitstream is not staged on the server under any of the
+       probed names; the mandatory ``loadpl_net`` step aborts netboot
+       (never boots a net kernel over an unprogrammed PL)
+     - Stage it in Step 1 with ``-B`` (and ``-M`` for a per-MAC copy), then
+       confirm ``curl -sf tftp://10.0.0.1/system.bit`` (or
+       ``.../system.bin``) fetches it back from the host
+   * - Board loads a stale bitstream even after re-running
+       ``provision_tftp_host.sh``
+     - A per-MAC name outranks the generic one, and a run without ``-M``
+       cannot clean per-MAC leftovers — it only warns about them
+     - Re-run with ``-M <board-MAC>``, which refreshes that per-MAC copy and
+       removes the other format's per-MAC name
+   * - ``tftp-only`` board fetches and loads a bitstream, but the PL ends up
+       running the SD card's one instead
+     - ``startup-app-init`` re-programs the PL with ``fpgautil`` whenever
+       ``/boot/system.bit`` exists, roughly 15 s into boot, discarding what
+       U-Boot loaded. ``tftp-only`` presumes a diskless board with no such
+       file
+     - Remove ``/boot/system.bit`` on boards that boot ``tftp-only``; the
+       served bitstream is only authoritative when it is absent
    * - ``ERROR: PL not programmed`` at the end of boot; no runtime
        application starts
      - ``startup-app-init`` found ``fpga_manager/fpga0/state`` not
@@ -483,12 +554,16 @@ Troubleshooting
        Confirm the ``KERNEL`` file named in the ``pxelinux.cfg`` is
        actually served (``curl -sf tftp://<serverip>/<name>``)
 
-On a ``fallback`` build, the SD fallback completes within roughly 6
-seconds of the TFTP failure. This holds whether the network actively
-refuses the connection or silently drops packets — both time out on
-the same schedule. If more than ~6 seconds have passed with no kernel
-banner, the fallback has already happened (or a ``tftp-only`` build
-has halted); there is nothing to gain by waiting longer.
+How long the SD fallback takes depends entirely on whether the TFTP
+server *answers*. A single ``tftpboot`` gives up after roughly 6 seconds,
+but ``netboot`` is PXE-first: ``pxe get`` tries 13 ``pxelinux.cfg`` names
+ahead of the direct FIT fetch, so a ``fallback`` board on a network with
+**no reachable TFTP server** pays that timeout 14 times over — about
+85 seconds with the daemon stopped, and about 110 seconds if packets are
+silently dropped. When the server *is* reachable and merely missing a
+file, every attempt is refused immediately and the fallback is effectively
+instant. Allow up to ~2 minutes before concluding a board has hung, and
+see the ``Request timeout`` entry in **Troubleshooting** above.
 
 Notes
 -----
@@ -520,7 +595,7 @@ Notes
      boots over an unprogrammed or stale PL.
 
 - The per-MAC bitstream filename is dash-separated
-  (``system.bit.bin.fc-c2-3d-5a-9a-08``), like the ``pxelinux.cfg``
+  (``system.bit.fc-c2-3d-5a-9a-08``), like the ``pxelinux.cfg``
   MAC form but without the ``01-`` prefix. U-Boot's ``tftpboot`` parses
   the first ``:`` in a filename as a ``hostIP:file`` separator, so a
   colon-form name (``${ethaddr}`` verbatim) is silently mis-parsed and
@@ -541,3 +616,89 @@ Notes
   bitstream the FPGA manager stays out of ``operating`` until something (the
   SD ``fpgautil`` load, or the ``tftp-only`` ``fpga load``) programs the PL,
   and the guard then skips the driver load as intended.
+
+.. _tftp-bitstream-formats:
+
+Bitstream formats: ``.bit`` and ``.bin``
+----------------------------------------
+
+``fpga load`` on this platform accepts a Vivado ``.bit`` and a
+bootgen-produced raw ``.bin``, and both program the same PL design. They
+are not, however, the same bytes. Beyond the ``.bit``'s 222-byte Vivado
+header (34,437,578 B versus 34,437,356 B for this design), ``bootgen``
+also byte-reverses every 32-bit word — the sync word is ``AA 99 55 66`` in
+the ``.bit`` and ``66 55 99 AA`` in the ``.bin``, and the bus-width-detect
+pattern ``00 00 00 BB`` / ``11 22 00 44`` is reversed the same way.
+Stripping the header off a ``.bit`` therefore does **not** produce the
+``.bin``: 2,363,968 of 34,437,356 bytes differ, a figure that looks small
+only because ``0x00000000`` and ``0xFFFFFFFF`` words are invariant under a
+word swap. An unconverted ``.bit`` loads because the PCAP auto-detects bus
+width and endianness from that pattern ahead of the sync word — not
+because the two payloads agree.
+
+The reason is in U-Boot's ZynqMP driver (``drivers/fpga/zynqmppl.c``).
+``zynqmp_load()`` calls its format validator **only** on ancient PMU
+firmware:
+
+.. code-block:: c
+
+   if (zynqmp_firmware_version() <= PMUFW_V1_0) {
+           ...
+           if (zynqmp_validate_bitstream(desc, buf, bsize, bsize, &swap))
+                   return FPGA_FAIL;
+           ...
+   } else {
+           bstype = 0;          /* modern PMUFW: no validation at all */
+   }
+
+On any current PMUFW the ``else`` branch is taken: U-Boot performs no
+sync-word scan, no byte-swap, and no format check, and hands the buffer
+verbatim to the PMU via ``PM_FPGA_LOAD``. The PMU's PCAP loader skips the
+``.bit`` header itself.
+
+.. important::
+
+   The two formats do not cost the same to load. Measured on this design's
+   34 MB bitstream (RFSoC 4x2, PMUFW from Vivado 2026.1):
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 25 25
+
+      * - Format
+        - ``fpga load``
+        - Total netboot
+      * - ``.bin``
+        - ~0.2 s
+        - ~40 s
+      * - ``.bit``
+        - ~16.6 s
+        - ~60 s
+
+   The TFTP transfer is identical either way (~17.6 MiB/s for both), so the
+   entire difference falls inside ``fpga load`` — consistent with the PMU
+   performing the word swap in software. Because ``loadpl_net`` prefers
+   ``.bit``, a board served one pays this on **every** boot. Prefer
+   ``-F bin`` where boot time matters and ``bootgen`` is available.
+
+.. warning::
+
+   None of this holds on PMUFW ≤ v1.0. There the validator runs,
+   ``check_data()`` locates the sync word at a nonzero offset, and the
+   load fails with ``Bitstream is not validated yet (diff ...)``. A raw
+   ``.bin`` is the only format that works across both, which is why
+   ``provision_tftp_host.sh -F bin`` still converts.
+
+   Staging both formats is **not** a way to cover both PMUFW generations.
+   ``loadpl_net``'s if/elif chain selects on *fetch* success, and the
+   ``fpga load`` result for whichever name it fetched is final. On
+   PMUFW ≤ v1.0 a co-present ``.bit`` would be fetched first, fail to load,
+   and halt the boot with the ``.bin`` sitting there untried.
+
+``loadpl_net`` probes ``.bit`` before ``.bin`` at each specificity level,
+so a leftover ``system.bit`` outranks a ``system.bin``.
+``provision_tftp_host.sh`` removes the unselected format's names — the
+generic one and one per ``-M`` MAC — so re-running it cannot leave a stale
+file of the other format behind. Without ``-M`` it cannot know the board's
+MAC and so cannot clean a per-MAC leftover; it warns about any it finds,
+since a per-MAC name outranks the generic one.

--- a/scripts/NETBOOT_BRINGUP_NOTES.md
+++ b/scripts/NETBOOT_BRINGUP_NOTES.md
@@ -51,24 +51,27 @@ stat -c%s /tmp/verify_image.ub                               # matches the built
 ## 2. Lab DHCP reality (shapes the DHCP design)
 
 The `10.0.0.0/24` lab net is **not** a bare private segment. A central **ISC `dhcpd`**
-(`/etc/dhcp/dhcpd.conf`, `INTERFACESv4=""` → answers on all matching interfaces including
-`eth2`) already serves it and is **shared across the dev boards**:
+(`/etc/dhcp/dhcpd.conf`, `INTERFACES="eth1 eth2"`) already serves it and is **shared across
+the dev boards**:
 
 ```
 subnet 10.0.0.0 netmask 255.255.255.0 {
   range 10.0.0.151 10.0.0.199;
   option routers 10.0.0.1;         # this host (rdsrv403)
-  host dev_zcu111 { fixed-address 10.0.0.10;  }
-  host dev_zcu208 { fixed-address 10.0.0.11;  }
-  host dev_zcu216 { fixed-address 10.0.0.12;  }
-  host slac_test1 { fixed-address 10.0.0.200; }
+  host dev_zcu111   { fixed-address 10.0.0.10;  }
+  host dev_zcu208   { fixed-address 10.0.0.11;  }
+  host dev_zcu216   { fixed-address 10.0.0.12;  }
+  host dev_rfsoc4x2 { fixed-address 10.0.0.13;  }   # fc:c2:3d:5a:9a:08
+  host slac_test1   { fixed-address 10.0.0.200; }
 }
 ```
 
-The RFSoC 4x2 (`fc:c2:3d:5a:9a:08`) takes a **dynamic lease** from this `dhcpd` (inside
-`.151–.199`); the exact address rotates between reboots, so **never gate pass/fail on the
-board's dynamic lease** — gate on the explicit `serverip 10.0.0.1` and on the observable
-boot outcome.
+The RFSoC 4x2 (`fc:c2:3d:5a:9a:08`) now has a **static reservation** at `10.0.0.13`, so its
+address is stable across reboots. It does **not** advertise `next-server`/`filename`, so
+`tftpserverip` is never set from DHCP and `serverip` resolves to the DHCP server's own
+address (`10.0.0.1`), which is also the TFTP server here. A board *without* a reservation
+takes a dynamic lease from `.151–.199` that rotates between reboots — for those, **never
+gate pass/fail on the lease address**; gate on `serverip` and on the observable boot outcome.
 
 **Consequence:** the host TFTP server runs **TFTP-only**. Running a second DHCP server
 (e.g. dnsmasq `dhcp-range`) on this segment races the lab `dhcpd` and can hand conflicting
@@ -121,7 +124,7 @@ At the `ZynqMP>` prompt (interrupt the autoboot) the exact working manual sequen
 dhcp                              # -> "DHCP client bound to address 10.0.0.xxx (N ms)" (lease from the lab dhcpd)
 setenv serverip 10.0.0.1          # explicit; do NOT rely on a DHCP next-server
 tftpboot 0x10000000 image.ub      # -> "Bytes transferred = <FIT size>"
-bootm 0x10000000                  # -> kernel boots -> "SimpleRfSoc4x2Example-<mode> login:"
+bootm 0x10000000                  # -> kernel boots -> "SimpleRfSoc4x2Example login:"
 ```
 - Load address **`0x10000000`** (project-proven, from the repo's own `boot.scr`) — **not**
   the generic `loadaddr=0x08000000` / `kernel_addr_r=0x18000000` defaults.
@@ -155,19 +158,27 @@ failed `label_boot()` (kernel retrieval failed) because `handle_pxe_menu()` is `
 the fallback**; the sequential form closes that gap without patching U-Boot. The decisive
 `pxe get` succeeds / `pxe boot` returns-0 case is re-validated on hardware in §6.
 
-The two build modes produce byte-distinct `BOOT.BIN` and `image.ub`:
+The two build modes produce byte-distinct `BOOT.BIN` and `image.ub`. Exact sizes and md5s
+change with every rebuild, so **do not compare against committed figures** — read the mode
+out of the artifact instead. The baked-in `bootcmd` is the definitive discriminator and never
+goes stale:
 
-| mode      | `BOOT.BIN` md5                     | `image.ub` size |
-|-----------|------------------------------------|-----------------|
-| fallback  | `87be1df7715527b53c9e7acdc696ca17` | `116833531`     |
-| tftp-only | `e5bb9930f864f9d7cc749261a95f6fc9` | `116833887`     |
+```
+strings -a BOOT.BIN | grep -a '^bootcmd='
+  bootcmd=run netboot; run sdboot                                  -> fallback
+  bootcmd=run netboot; echo TFTP-only build: not falling back to SD -> tftp-only
+```
+`strings -a BOOT.BIN | grep -aE '^(netboot|loadpl_net|loadpl_skip)='` likewise shows whether
+`netboot` calls `run loadpl_net` (tftp-only) or `run loadpl_skip` (fallback). This works on a
+built artifact *or* on the SD copy at `/boot/BOOT.BIN`, with no board involved. For scale, the
+build current at the time of writing produced `image.ub` = `116835243` B and `BOOT.BIN` =
+`36383360` B in `fallback` mode.
 
 On the committed build the login banner is `SimpleRfSoc4x2Example` for **both** modes: the
 hostname is set from the project name (`hostname:pn-base-files = "$Name"`), independent of
-`UBOOT_NETBOOT_MODE`, so it is **not** a mode distinguisher. Tell which build actually booted
-from the byte-distinct `BOOT.BIN` md5 (the two modes differ — see the table above), or from
-the TFTP-failure behavior itself (a `fallback` build SD-boots; a `tftp-only` build halts at
-`ZynqMP>`).
+`UBOOT_NETBOOT_MODE`, so it is **not** a mode distinguisher. Besides the `bootcmd` check
+above, the TFTP-failure behavior also tells the modes apart (a `fallback` build SD-boots; a
+`tftp-only` build halts at `ZynqMP>`).
 
 ### Static-IP override (no-DHCP path)
 At `ZynqMP>`, set `ipaddr` (e.g. `10.0.0.50` — outside the dhcpd pool, not a fixed host,
@@ -221,8 +232,13 @@ Both build modes were exercised on the board with TFTP made unreachable two ways
 
 ### Fallback build (`UBOOT_NETBOOT_MODE=fallback`), TFTP down → boots SD
 On a failed `run netboot`, the else-branch runs `sdboot`, which boots the on-SD `image.ub`
-to a kernel banner and `SimpleRfSoc4x2Example-fallback login:`. Two TFTP-down mechanisms,
-two **distinct** bounded timeouts (keep them separate):
+to a kernel banner and `SimpleRfSoc4x2Example login:`. Two TFTP-down mechanisms,
+two **distinct** bounded timeouts (keep them separate).
+
+> **These are per-`tftpboot` figures, measured before the PXE-first hook existed.** They are
+> still correct per attempt, but they are **not** the end-to-end fallback time on the current
+> code: `pxe get` now issues 13 config-name attempts ahead of the FIT fetch, each paying the
+> timeout below. See §6 for the ~85–110 s aggregate.
 
 | Mechanism | Host TFTP state | Serial signature | Bounded fallback time |
 |-----------|-----------------|------------------|-----------------------|
@@ -254,8 +270,8 @@ TFTP-only build: not falling back to SD
 ZynqMP>
 ```
 This is the decisive contrast with the fallback build: same failure, opposite outcome.
-With TFTP **up**, the tftp-only build netboots normally (`Bytes transferred = 116833887` →
-`## Loading kernel (any) from FIT Image at 10000000` → `SimpleRfSoc4x2Example-tftponly login:`).
+With TFTP **up**, the tftp-only build netboots normally (`Bytes transferred = <FIT size>` →
+`## Loading kernel (any) from FIT Image at 10000000` → `SimpleRfSoc4x2Example login:`).
 
 ### Recovering a halted tftp-only board
 ```
@@ -273,9 +289,11 @@ Added after the bring-up above, in response to the PR review. The netboot hook i
 **PXE-first**: `pxe get` fetches a pxelinux config from `${serverip}` and `pxe boot` loads
 and boots the FIT that config names; the direct `tftpboot 0x10000000 image.ub && bootm
 0x10000000` stays as the in-`netboot` fallback for when no PXE config is served. The
-expanded `netboot` env value:
+expanded `netboot` env value (as shipped today, including the `serverip` save/restore from
+§2 and the `@LOADPL_SEL@` bitstream hook from §7 — `run loadpl_skip` shown here for a
+`fallback` build):
 ```
-if test -n "${ipaddr}"; then true; else dhcp; fi && if pxe get; then pxe boot; else tftpboot 0x10000000 image.ub && bootm 0x10000000; fi
+if test -n "${ipaddr}"; then true; else if test -n "${serverip}"; then setenv _sip ${serverip}; dhcp && setenv serverip ${_sip} && setenv tftpserverip && setenv _sip; else dhcp; fi; fi && run loadpl_skip && if pxe get; then pxe boot; else tftpboot 0x10000000 image.ub && bootm 0x10000000; fi
 ```
 
 - **Config search order** (built into `pxe get`): the MAC-based name
@@ -321,8 +339,8 @@ if test -n "${ipaddr}"; then true; else dhcp; fi && if pxe get; then pxe boot; e
   - *PXE default happy path* — `run netboot` → `pxe get` fetches `pxelinux.cfg/default` →
     `pxe boot` loads the `KERNEL` FIT at `kernel_addr_r` (`0x18000000`) → boots to `login:`.
     The observed `pxe get` search order matches the documented one exactly: MAC
-    (`pxelinux.cfg/01-fc-c2-3d-5a-9a-08`) → descending IP-hex (`0A00009B`…`0A`) →
-    `default-<arch>`… → `default`.
+    (`pxelinux.cfg/01-fc-c2-3d-5a-9a-08`) → descending IP-hex (`0A00000D`…`0`, for
+    `10.0.0.13`) → `default-<arch>`… → `default`, 13 names in total.
   - *MAC-specific override* — a `pxelinux.cfg/01-<mac>` file naming a different FIT is taken
     in preference to `default`; the board boots the FIT the MAC file names.
   - *No PXE config served* — `pxe get` fails and the in-`netboot` fallback
@@ -350,17 +368,35 @@ if test -n "${ipaddr}"; then true; else dhcp; fi && if pxe get; then pxe boot; e
     older stock build predating the hooks, so a baked-in `printenv` byte-match awaits the
     next full rebuild+reflash). The positive path was also re-run end-to-end: the full new
     `netboot` (serverip preserved across `dhcp`) → `pxe get` default → `pxe boot` →
-    `SimpleRfSoc4x2Example-tftponly login:`.
-- **Silent-black-hole failure is now slow (~110 s); the port-closed case stays fast
-  (~6 s).** This is a behavioral change the PXE-first hook introduces relative to Section
-  5's pre-PXE figures, and it is worth accounting for wherever a bounded fallback time
-  matters. When TFTP packets are silently dropped, each of `pxe get`'s ~12 config-name
-  probes (MAC + IP-hex prefixes + `default-*` variants) waits its full TFTP request timeout
-  with no ICMP to short-circuit it, so `netboot` takes ~110 s to fail before the `bootcmd`
-  else-branch (SD fallback or halt) runs. The port-closed case (dnsmasq down) stays ~6 s
-  because ICMP destination-unreachable aborts each probe immediately. Section 5's ~5 s
-  silent-black-hole figure was for the single pre-PXE `tftpboot`; the PXE-first worst case
-  under a silent drop is ~110 s.
+    `SimpleRfSoc4x2Example login:`.
+- **PXE-first multiplies every TFTP-failure timeout by the probe count (~85–110 s).** This is
+  a behavioral change the PXE-first hook introduces relative to Section 5's pre-PXE figures,
+  and it matters wherever a bounded fallback time does. `pxe get` walks **13** config names
+  (MAC → 9 IP-hex prefixes → 3 `default-*` variants → `default`), and the in-`netboot`
+  `tftpboot image.ub` adds a 14th attempt. Whether an attempt is cheap or expensive depends
+  only on whether the server *answers*:
+
+  | Host TFTP state | Per-attempt cost | 14 attempts |
+  |-----------------|------------------|-------------|
+  | up, file absent | immediate `TFTP error: 256` NAK | negligible |
+  | down (port closed) | full request timeout, ~6 s | **≈ 85 s** |
+  | silent DROP (black hole) | full request timeout | ≈ 110 s |
+
+  **ICMP does not short-circuit a probe.** An earlier revision of this section claimed the
+  port-closed case "stays fast (~6 s) because ICMP destination-unreachable aborts each probe
+  immediately." That is wrong. Re-measured on the RFSoC 4x2 with dnsmasq stopped: the ICMP
+  *does* arrive — 6 `ICMP destination unreachable (port unreachable)` lines per attempt, as
+  Section 5 records — and each attempt **still** ends in `TFTP error: -1 (Request timeout)`.
+  Boot-to-SSH took **134.5 s**, against **50.0 s** for the same 14 attempts with the server up
+  and NAK'ing: a delta of 84.5 s over 14 attempts, i.e. ≈ 6.0 s each. Section 5's ≈ 5–6 s
+  figures are per-`tftpboot` and remain correct; what changed is that PXE-first fires fourteen
+  of them, so port-closed and black-hole failures now cost the same order of magnitude rather
+  than differing by ~20×.
+
+  Note this cost is paid by a `fallback` board on **every** boot on a net with no TFTP server,
+  which is the usual idle-lab state. Staging `pxelinux.cfg/01-<mac-dashes>` collapses the
+  13-name search to a single hit (it is the first name probed) and is the cheapest mitigation;
+  `provision_tftp_host.sh` currently writes only `pxelinux.cfg/default`.
 
 ---
 
@@ -374,7 +410,7 @@ fetches the bitstream over TFTP and `fpga load`s it before booting the kernel �
 
 ### Where the PL bitstream comes from today (the gap this closes)
 - **`BOOT.BIN` embeds the bitstream** — FSBL programs the PL from SD/QSPI at boot. Confirmed
-  by size: RFSoC 4x2 `BOOT.BIN` is **36 382 960 B** vs `system.bit` **34 437 578 B**
+  by size: RFSoC 4x2 `BOOT.BIN` is **36 383 360 B** vs `system.bit` **34 437 578 B**
   (`BOOT.BIN` = FSBL+PMU+ATF+U-Boot + the ~34 MB bitstream). So a diskless QSPI board is
   frozen at the baked-in PL until QSPI is reflashed.
 - **Runtime reload** — on an SD boot, `startup-app-init` mounts the SD FAT at `/boot` and runs
@@ -394,8 +430,8 @@ fetches the bitstream over TFTP and `fpga load`s it before booting the kernel �
 | `fallback` (default) | `loadpl_skip` (`true`) | no-op; SD `fpgautil` owns the PL (no double-program) |
 
 ```
-loadpl_net = setexpr macfn gsub : - ${ethaddr} && if tftpboot 0x10000000 system.bit.bin.${macfn}; then true; else tftpboot 0x10000000 system.bit.bin; fi && fpga load 0 0x10000000 ${filesize}
-netboot    = if test -n "${ipaddr}"; then true; else dhcp; fi && run @LOADPL_SEL@ && if pxe get; then pxe boot; else tftpboot 0x10000000 image.ub && bootm 0x10000000; fi
+loadpl_net = setexpr macfn gsub : - ${ethaddr} && if tftpboot 0x10000000 system.bit.${macfn}; then true; elif tftpboot 0x10000000 system.bin.${macfn}; then true; elif tftpboot 0x10000000 system.bit; then true; else tftpboot 0x10000000 system.bin; fi && fpga load 0 0x10000000 ${filesize}
+netboot    = if test -n "${ipaddr}"; then true; else if test -n "${serverip}"; then setenv _sip ${serverip}; dhcp && setenv serverip ${_sip} && setenv tftpserverip && setenv _sip; else dhcp; fi; fi && run @LOADPL_SEL@ && if pxe get; then pxe boot; else tftpboot 0x10000000 image.ub && bootm 0x10000000; fi
 ```
 
 - **Halt-on-failure by `&&` chaining.** In `tftp-only`, a failed bitstream fetch **or** a
@@ -406,22 +442,50 @@ netboot    = if test -n "${ipaddr}"; then true; else dhcp; fi && run @LOADPL_SEL
   (PCAP program) before the kernel FIT is fetched to the same address. `${filesize}` is set by
   whichever `tftpboot` (per-MAC or generic) succeeded, and is consumed by `fpga load` before
   the next `tftpboot` overwrites it.
-- **Per-MAC naming is dash-form** (`system.bit.bin.fc-c2-3d-5a-9a-08`), then falls back to
-  generic `system.bit.bin`. U-Boot's `tftpboot` parses the first `:` in a filename as a
-  `hostIP:file` separator, so `system.bit.bin.${ethaddr}` (colon form) is silently mis-parsed
+- **Per-MAC naming is dash-form** (`system.bit.fc-c2-3d-5a-9a-08`), falling back through
+  `system.bin.<mac>` and `system.bit` to generic `system.bin`. U-Boot's `tftpboot`
+  parses the first `:` in a filename as a
+  `hostIP:file` separator, so `system.bin.${ethaddr}` (colon form) is silently mis-parsed
   and never fetched (observed on HW — see below). `loadpl_net` therefore runs
   `setexpr macfn gsub : - ${ethaddr}` to rewrite colons to dashes, then fetches
-  `system.bit.bin.${macfn}`. `setexpr gsub` needs `CONFIG_CMD_SETEXPR` + `CONFIG_REGEX` (both
-  on in the ZynqMP defconfig — verified in the built `.config`).
+  `system.bit.${macfn}`. `setexpr gsub` needs `CONFIG_CMD_SETEXPR` + `CONFIG_REGEX` (both
+  on in the ZynqMP defconfig — verified in the built `.config`). A miss returns an immediate
+  TFTP NAK rather than a timeout, so the extra probes cost ~nothing.
+- **Either `.bit` or `.bin` loads.** `zynqmp_load()` (`drivers/fpga/zynqmppl.c`) calls
+  `zynqmp_validate_bitstream()` **only** when `zynqmp_firmware_version() <= PMUFW_V1_0`; on
+  current PMUFW it takes the `else { bstype = 0; }` branch, does no sync-word scan and no
+  byte-swap, and hands the buffer verbatim to the PMU via `PM_FPGA_LOAD`. The PMU's PCAP
+  loader skips the Vivado header, so an unconverted `.bit` programs fine — confirmed in the
+  field before it was confirmed in the source. The size delta seen here is exactly the header:
+  `system.bit` 34 437 578 B vs the staged `.bin` 34 437 356 B = **222 B**. On PMUFW ≤ v1.0 the
+  validator does run and rejects a `.bit`: `check_data()` finds the sync word at a nonzero
+  offset and the `diff` check fails with `Bitstream is not validated yet`. `-F bin` keeps
+  converting for that reason.
+- **…but the two files are not the same bytes, and the `.bit` is far slower.** The *size* delta
+  is exactly the header, yet `bootgen` also byte-reverses every 32-bit word (sync
+  `AA 99 55 66` → `66 55 99 AA`; bus-width `00 00 00 BB` → `BB 00 00 00`), so **2 363 968 of
+  34 437 356 bytes differ** and stripping the header off a `.bit` does not yield the `.bin`. The
+  `.bit` loads because the PCAP auto-detects bus width/endianness from the `000000BB/11220044`
+  pattern ahead of the sync word — not because the payloads agree. Measured cost:
+  **~16.6 s** in `fpga load` for a `.bit` versus **~0.2 s** for a `.bin`, with an identical
+  ~17.6 MiB/s TFTP transfer either way (~60 s vs ~40 s total netboot). Since `.bit` is preferred
+  at each specificity level, a `.bit`-served board pays that on every boot.
 - **Kconfig pinned** in `bsp.cfg`: `CONFIG_FPGA`, `CONFIG_FPGA_XILINX`, `CONFIG_FPGA_ZYNQMPPL`,
   `CONFIG_CMD_FPGA` (normally already on via the ZynqMP defconfig; pinned since the feature
   hard-depends on `fpga load`). Verify present in the built `.config`.
 
 ### Host staging
-`provision_tftp_host.sh -B` converts `linux/system.bit` → raw `.bin`
-(`bootgen -arch zynqmp -image <bif> -process_bitstream bin`; needs Vitis/Vivado `bootgen` on
-`PATH`) and stages `/tftpboot/system.bit.bin`; `-M <mac>` (repeatable) adds per-MAC copies.
-Idempotent (`cmp`-guarded) like the `image.ub`/PXE steps. Fallback-mode servers omit `-B`/`-M`.
+`provision_tftp_host.sh -B` stages `linux/system.bit` unconverted as `/tftpboot/system.bit` —
+no bootgen, no Vitis environment — which is the name `loadpl_net` probes first. `-F bin`
+converts to a raw `.bin` instead (`bootgen -arch zynqmp -image <bif> -process_bitstream bin`;
+needs Vitis/Vivado `bootgen` on `PATH`) and stages `/tftpboot/system.bin`. `-M <mac>`
+(repeatable) adds per-MAC copies of whichever format is selected. Idempotent (`cmp`-guarded)
+like the `image.ub`/PXE steps. Fallback-mode servers omit `-B`/`-F`/`-M`.
+
+Staging one format removes the other's names — the generic one plus each `-M` MAC — so a stale
+`system.bit` can no longer outrank a freshly staged `system.bin`. A run without `-M` cannot know
+the board's MAC and so cannot clean a per-MAC leftover; it warns instead, since any per-MAC name
+outranks the generic one.
 
 ### `startup-app-init` backstop
 Before the DMA `insmod`s, it checks `/sys/class/fpga_manager/fpga0/state`; if not `operating`
@@ -433,19 +497,19 @@ secondary backstop, not the mode guard.
 ### Hardware validation — Stage A (SD-simulated diskless), all PASS on the RFSoC 4x2
 Method: reflash the SD `BOOT.BIN` in place with the tftp-only build (Linux VFAT `cp`), rename
 `/boot/system.bit` → `system.old` so the runtime `fpgautil` step is skipped (isolating the PL
-to the U-Boot `fpga load`), stage `image.ub` + `system.bit.bin` (+ per-MAC) with
+to the U-Boot `fpga load`), stage `image.ub` + `system.bin` (+ per-MAC) with
 `provision_tftp_host.sh -B -M`, boot, and capture serial. `${filesize}` is set by `tftpboot`
 under lwIP (confirmed — `fpga load` consumed it). Observed:
 
 - **Per-MAC bitstream fetch + fpga load + net kernel boot.** `DHCP client bound` →
-  `Filename 'system.bit.bin.fc-c2-3d-5a-9a-08'` → `Bytes transferred = 34437356` → `fpga load`
+  `Filename 'system.bin.fc-c2-3d-5a-9a-08'` → `Bytes transferred = 34437356` → `fpga load`
   (silent, `FPGA_RC=0` confirmed at the prompt) → `pxe get` finds `pxelinux.cfg/default` → kernel
-  FIT at `0x18000000` → `SimpleRfSoc4x2Example-tftponly login:`. In Linux the DMA drivers bound
+  FIT at `0x18000000` → `SimpleRfSoc4x2Example login:`. In Linux the DMA drivers bound
   (`axi_stream_dma … Found Version 2 Device`) and `axiversiondump` read `Root.AxiVersion`
   (`FwVersion 0x3030000`) — i.e. the PL is programmed and the app runs.
 - **Per-MAC → generic fallback.** With the per-MAC file removed:
-  `Filename 'system.bit.bin.fc-c2-3d-5a-9a-08'` → `TFTP error: 256 (… not found)` →
-  `Filename 'system.bit.bin'` → `Bytes transferred = 34437356` → boots. The `if…else…fi` falls
+  `Filename 'system.bin.fc-c2-3d-5a-9a-08'` → `TFTP error: 256 (… not found)` →
+  `Filename 'system.bin'` → `Bytes transferred = 34437356` → boots. The `if…else…fi` falls
   through exactly as intended.
 - **Halt-on-failure (tftp-only).** With **both** bitstream files removed:
   per-MAC MISS → generic MISS → `TFTP-only build: not falling back to SD` → **halt at
@@ -454,11 +518,12 @@ under lwIP (confirmed — `fpga load` consumed it). Observed:
   `reset` recovers it.
 
 **LANDMINE (found on HW): a colon-form per-MAC name does not work.** The first cut used
-`system.bit.bin.${ethaddr}` (colon form). U-Boot's `tftpboot` parses the first `:` in a filename
+`system.bin.${ethaddr}` (colon form). U-Boot's `tftpboot` parses the first `:` in a filename
 as a `hostIP:file` separator, so it silently skipped the per-MAC attempt and went straight to the
 generic name — no per-MAC line, no error. Fix: `setexpr macfn gsub : - ${ethaddr}` (validated
-live: `ethaddr=fc:c2:3d:5a:9a:08` → `macfn=fc-c2-3d-5a-9a-08`) and request
-`system.bit.bin.${macfn}`; `provision_tftp_host.sh -M` stores the dash form to match.
+live: `ethaddr=fc:c2:3d:5a:9a:08` → `macfn=fc-c2-3d-5a-9a-08`) and request the per-MAC name in
+dash form; `provision_tftp_host.sh -M` stores the dash form to match. The constraint is about
+the colon, not the name — it applies equally to `system.bit.<mac>` and `system.bin.<mac>`.
 
 Note: `fpga0/state` read `operating` here even in the disabled-SD case, because the tftp-only
 `BOOT.BIN` still carries an FSBL bitstream that programs the PL before U-Boot runs — so the
@@ -466,3 +531,73 @@ state check cannot by itself prove the `fpga load` ran. The decisive proof is th
 halt (a failed `fpga load` would have halted before Linux) plus `FPGA_RC=0` at the prompt.
 
 The literal no-SD QSPI diskless boot (Stage B) is deferred by decision — not run.
+
+---
+
+## 8. Hardware validation — Stage C (bitstream-format matrix), all PASS on the RFSoC 4x2
+
+Run after `loadpl_net` was changed to probe four names. Method as Stage A (tftp-only `BOOT.BIN`
+flashed by Linux VFAT `cp`, `/boot/system.bit` parked so the runtime `fpgautil` step cannot
+override the fetch), staging exactly one name set per boot and reading the fetched `Filename`
+and `Bytes transferred` off the serial console. `.bit` = 34 437 578 B, `.bin` = 34 437 356 B,
+which makes every case unambiguous.
+
+| # | staged | fetched | misses first | `fpga load` | outcome |
+|---|--------|---------|--------------|-------------|---------|
+| T1 | `system.bin` | `system.bin` | 3 | 0.00 s | boots |
+| T2 | `system.bit` | `system.bit` | 2 | 16.60 s | boots |
+| T3 | both generic | `system.bit` | 2 | 16.60 s | boots — `.bit` preferred |
+| T4 | `system.bin.<mac>` | `system.bin.<mac>` | 1 | 0.20 s | boots |
+| T5 | `system.bit.<mac>` | `system.bit.<mac>` | 0 | 16.60 s | boots |
+| T6 | all four | `system.bit.<mac>` | 0 | 16.60 s | boots — full precedence |
+| T7 | `.bit.<mac>` + `.bin` | `system.bit.<mac>` | 0 | 16.80 s | boots — per-MAC beats generic |
+| T8 | nothing | — | 4 | — | **halts at `ZynqMP>`** |
+
+- All four T8 misses landed inside **1 ms**, confirming that a miss costs an immediate NAK and
+  not a timeout. No kernel was fetched in T8 **even though `image.ub` was staged and reachable**,
+  proving the abort came from the bitstream step via the `&&` chain rather than a missing FIT.
+- Recovery from the T8 halt (re-stage, `reset` over serial, per §5) worked first try.
+
+### Conclusive format proof
+Because `BOOT.BIN` embeds an FSBL bitstream, the cases above cannot by themselves show that the
+*fetched* bitstream is what ends up running (same caveat as §7's `fpga0/state` note). Rebuilt
+with `BIF_BITSTREAM_ATTR = ""` — 1 946 016 B, no `download-zynqmp-user.bit` partition — with
+`/boot/system.bit` still parked, so the TFTP fetch became the only possible programmer. Both a
+`.bit` and a `.bin` then bound `axi_memory_map` at `0x400000000` and `axi_stream_dma` at
+`0xb0000000` ("Found Version 2 Device") and answered `axiversiondump`. Those are PL-side
+registers, so the fetched bitstream configures the fabric in either format.
+
+### `startup-app-init` guard
+Exercised for the first time with `BIF_BITSTREAM_ATTR = ""`, `fallback` mode and no
+`/boot/system.bit`: it printed `ERROR: PL not programmed …` and skipped the driver load, with
+zero driver-bind lines — the diagnosis lands as intended.
+
+Note that the guard wraps only the two `insmod`s. `axiversiondump` and the runtime app run
+afterwards regardless and both die on `/dev/axi_memory_map`, so the service respawns roughly every
+3 s, re-emitting the diagnosis plus two Python tracebacks (PIDs climbed 262 → 1233 in ~90 s).
+Expect a noisy console rather than a single message. The board is non-functional in this state
+either way, and the retry is self-healing: program the PL by hand and a later pass gets past the
+guard and loads the drivers.
+
+### Fallback regression
+With TFTP up, `fallback` made **zero** bitstream probes even with `system.bin` staged and
+reachable (`loadpl_skip` is a bare `true`), and netbooted via `pxe get` → `default` → `image.ub`.
+With the FIT and PXE config unstaged, `pxe get` exhausted every `pxelinux.cfg` name, the
+in-`netboot` direct `tftpboot image.ub` NAK'd, and `run sdboot` booted the on-SD `image.ub`
+(14.4 MiB/s). This used an immediate NAK (files unstaged) rather than either §5 timeout
+mechanism, both of which need root on the shared lab host. The port-closed mechanism has since
+been re-measured with `pxe get` in front of it — see §6: the per-attempt figure holds at ≈ 6 s,
+but 14 attempts make the end-to-end fallback ≈ 85 s, and ICMP does not cut an attempt short.
+
+### The login banner is not a mode indicator
+Confirmed: every case in both modes printed the same `SimpleRfSoc4x2Example login:`.
+`BuildYoctoProject.sh` sets `hostname:pn-base-files` from the target name with no
+`UBOOT_NETBOOT_MODE` dependency, so no `-fallback`/`-tftponly` suffix exists in these builds.
+Distinguish modes by the `BOOT.BIN` md5 or the TFTP-failure behavior.
+
+### Editing `UBOOT_NETBOOT_MODE` does not need a `cleansstate`
+Changing it in `build/conf/local.conf` and running `bitbake xilinx-bootbin` re-ran 29 of 1972
+tasks and produced the other mode's `BOOT.BIN` (`run loadpl_net` present, `run loadpl_skip`
+absent). The variable is referenced by the u-boot bbappend's `do_configure`, so BitBake's
+signature tracking picks it up. This is how Stage C switched modes without a `-c` reconfigure,
+which would have re-run `repo sync` in the middle of the run.

--- a/scripts/provision_tftp_host.sh
+++ b/scripts/provision_tftp_host.sh
@@ -15,10 +15,26 @@
 ## pxelinux.cfg/default PXE config that names it. Safe to re-run --
 ## a no-op re-invocation does not re-prompt for sudo and does not re-copy.
 ##
-## With -B, also stages the PL bitstream as a raw .bin (system.bit.bin, plus
-## per-MAC copies via -M) for the tftp-only (diskless) build, whose U-Boot env
-## fetches and 'fpga load's it before booting the kernel. Fallback-mode servers
-## do not need this -- omit -B and only image.ub/PXE are staged.
+## With -B, also stages the PL bitstream (plus per-MAC copies via -M) for the
+## tftp-only (diskless) build, whose U-Boot env fetches and 'fpga load's it
+## before booting the kernel. Fallback-mode servers do not need this -- omit -B
+## and only image.ub/PXE are staged.
+##
+## -F selects the format. The default is the unconverted Vivado .bit: it needs no
+## bootgen and is the name loadpl_net probes first, so it is the common case.
+## 'fpga load' accepts it on current PMUFW at the cost of a much slower load
+## (~16.6 s versus ~0.2 s for a raw .bin, measured on this design's 34 MB
+## bitstream). -F bin converts with bootgen and is required on PMUFW <= v1.0,
+## where the validator runs and rejects a .bit.
+##
+## The formats are mutually exclusive on purpose. loadpl_net's if/elif chain
+## selects on fetch success, so the highest-ranked staged name wins the probe and
+## its 'fpga load' result is final. Staging both would therefore not give a
+## PMUFW <= v1.0 board a working fallback: the .bit outranks the .bin, is fetched
+## first, fails to load, and halts the boot with the .bin never tried. Staging one
+## format consequently removes the other's names, which also closes the stale-file
+## hazard of a leftover system.bit outranking a freshly staged system.bin.
+## See docs/how-to/tftp_network_boot.rst, "Bitstream formats".
 ##
 ## Reference (proven manual procedure this script formalizes):
 ##   axi-soc-ultra-plus-core/scripts/NETBOOT_BRINGUP_NOTES.md, sections 1 and 3.
@@ -36,14 +52,21 @@ PIDFILE=/run/dnsmasq-tftp-lab.pid
 board=
 srcOverride=
 stageBitstream=0
+bitFormat=bit
 macs=()
 
 function show_help {
-   echo "USAGE: $0 -b BOARD [-f PATH] [-B] [-M MAC] [-H]"
+   echo "USAGE: $0 -b BOARD [-f PATH] [-B] [-F FORMAT] [-M MAC] [-H]"
    echo " -b BOARD     - Board name, must match a directory name in axi-soc-ultra-plus-core/hardware (required)"
    echo " -f PATH      - Explicit image.ub source path (bypasses build-dir auto-detect)"
-   echo " -B           - Also stage the PL bitstream (system.bit -> system.bit.bin) for tftp-only/diskless netboot"
-   echo " -M MAC       - Stage a per-MAC bitstream copy system.bit.bin.<mac-dashes> (repeatable; implies -B; MAC colons or dashes, stored dash-form)"
+   echo " -B           - Also stage the PL bitstream for tftp-only/diskless netboot (format from -F, default 'bit')"
+   echo " -F FORMAT    - Bitstream format, implies -B:"
+   echo "                  bit - copy linux/system.bit unconverted (default; no bootgen needed; probed first)"
+   echo "                  bin - convert with bootgen to a raw .bin (needs bootgen on PATH; loads far faster,"
+   echo "                        and is the only format accepted on PMUFW <= v1.0)"
+   echo "                Staging one format removes the other's names; they are not usable side by side."
+   echo " -M MAC       - Also stage a per-MAC copy of the staged format (repeatable; implies -B;"
+   echo "                MAC colons or dashes, stored dash-form)"
    echo " -H           - Show this help text"
    exit 1
 }
@@ -53,15 +76,16 @@ function die {
     exit 1
 }
 
-while getopts b:f:BM:H flag
+while getopts b:f:BF:M:H flag
 do
     case "${flag}" in
         b) board=${OPTARG};;
         f) srcOverride=${OPTARG};;
         B) stageBitstream=1;;
+        F) stageBitstream=1; bitFormat="${OPTARG,,}";;
         # Store the MAC lowercased with ':' -> '-'. U-Boot's tftpboot treats the
         # first ':' in a filename as a hostIP separator, so the board's loadpl_net
-        # uses 'setexpr gsub' to request system.bit.bin.<mac-dashes>; the staged
+        # uses 'setexpr gsub' to request system.<fmt>.<mac-dashes>; the staged
         # filename must match that dash form. Accepts -M with colons or dashes.
         M) stageBitstream=1; m="${OPTARG,,}"; macs+=("${m//:/-}");;
         H) show_help;;
@@ -70,6 +94,11 @@ do
 done
 
 [ -n "$board" ] || { echo "Missing required -b BOARD"; show_help; }
+
+case "$bitFormat" in
+   bit|bin) ;;
+   *) echo "Invalid -F FORMAT '$bitFormat' (expected 'bit' or 'bin')"; show_help;;
+esac
 
 ##############################################################################
 # Check for missing host tools before we start
@@ -223,43 +252,56 @@ else
 fi
 
 ##############################################################################
-# Step 5 (optional, -B/-M): stage the PL bitstream as a raw .bin for the
-# tftp-only (diskless) build. The build produces linux/system.bit (a .bit with
-# a Vivado header) next to image.ub; U-Boot's 'fpga load' wants the raw PL
-# config .bin, so convert with bootgen. Stage the generic system.bit.bin plus
-# a per-MAC copy for each -M (U-Boot's loadpl_net tries system.bit.bin.<ethaddr>
-# first, then the generic name). Same check-then-act idempotency as above.
+# Step 5 (optional, -B/-F/-M): stage the PL bitstream for the tftp-only
+# (diskless) build. The build produces linux/system.bit (a .bit with a Vivado
+# header) next to image.ub.
+#
+# -F bit (the default) copies it unconverted: no bootgen, and it is the first
+# name loadpl_net probes. -F bin converts it with bootgen, which loads far faster
+# on current PMUFW and is the only format accepted on PMUFW <= v1.0.
+#
+# loadpl_net probes system.bit.<mac> -> system.bin.<mac> -> system.bit ->
+# system.bin and the 'fpga load' result for whichever name it fetches is final,
+# so the formats cannot coexist usefully. The unselected format's names are
+# removed once staging succeeds, rather than left behind to outrank the names
+# written here. Same check-then-act idempotency as the steps above.
 ##############################################################################
 
 if [ "$stageBitstream" -eq 1 ]; then
-   command -v bootgen >/dev/null 2>&1 || \
-      die "bootgen not found in PATH (source your Vitis/Vivado settings64.sh); required for -B/-M .bit->.bin conversion"
-
    bitSrc="$(dirname "$src")/system.bit"  # sits next to the resolved image.ub
    [ -f "$bitSrc" ] || die "No system.bit found next to image.ub at '$bitSrc'"
 
-   # Convert .bit -> raw .bin in an isolated temp dir so bootgen's output name
-   # (which is version-dependent) does not matter -- we glob the single *.bin.
-   tmpBit=$(mktemp -d)
-   trap 'rm -rf "$tmpBit"' EXIT
-   cp "$bitSrc" "$tmpBit/system.bit"
-   printf 'all:\n{\n    system.bit\n}\n' > "$tmpBit/bitstream.bif"
-   ( cd "$tmpBit" && bootgen -arch zynqmp -image bitstream.bif -process_bitstream bin >/dev/null ) \
-      || die "bootgen .bit->.bin conversion failed"
-   binOut=$(find "$tmpBit" -maxdepth 1 -name '*.bin' | head -1)
-   [ -n "$binOut" ] || die "bootgen produced no .bin in $tmpBit"
+   if [ "$bitFormat" = "bin" ]; then
+      command -v bootgen >/dev/null 2>&1 || \
+         die "bootgen not found in PATH (source your Vitis/Vivado settings64.sh); required for -F bin"
 
-   bitDest="$TFTP_ROOT/system.bit.bin"
-   if cmp -s "$binOut" "$bitDest" 2>/dev/null; then
+      # Convert .bit -> raw .bin in an isolated temp dir so bootgen's output name
+      # (which is version-dependent) does not matter -- we glob the single *.bin.
+      tmpBit=$(mktemp -d)
+      trap 'rm -rf "$tmpBit"' EXIT
+      cp "$bitSrc" "$tmpBit/system.bit"
+      printf 'all:\n{\n    system.bit\n}\n' > "$tmpBit/bitstream.bif"
+      ( cd "$tmpBit" && bootgen -arch zynqmp -image bitstream.bif -process_bitstream bin >/dev/null ) \
+         || die "bootgen .bit->.bin conversion failed"
+      staged=$(find "$tmpBit" -maxdepth 1 -name '*.bin' | head -1)
+      [ -n "$staged" ] || die "bootgen produced no .bin in $tmpBit"
+      otherFormat=bit
+   else
+      staged="$bitSrc"
+      otherFormat=bin
+   fi
+
+   bitDest="$TFTP_ROOT/system.$bitFormat"
+   if cmp -s "$staged" "$bitDest" 2>/dev/null; then
       echo "$bitDest already up to date"
    else
-      echo "Staging $bitSrc -> $bitDest ($(stat -c%s "$binOut") bytes .bin)"
-      cp "$binOut" "$bitDest"
-      cmp -s "$binOut" "$bitDest" || die "Post-copy verification failed: $bitDest"
+      echo "Staging $bitSrc -> $bitDest ($(stat -c%s "$staged") bytes .$bitFormat)"
+      cp "$staged" "$bitDest"
+      cmp -s "$staged" "$bitDest" || die "Post-copy verification failed: $bitDest"
    fi
 
    for mac in ${macs[@]+"${macs[@]}"}; do
-      macDest="$TFTP_ROOT/system.bit.bin.$mac"
+      macDest="$TFTP_ROOT/system.$bitFormat.$mac"
       if cmp -s "$bitDest" "$macDest" 2>/dev/null; then
          echo "$macDest already up to date"
       else
@@ -268,4 +310,27 @@ if [ "$stageBitstream" -eq 1 ]; then
          cmp -s "$bitDest" "$macDest" || die "Post-copy verification failed: $macDest"
       fi
    done
+
+   # Only now that the selected format is staged and verified, drop the other
+   # format's names -- doing it earlier would leave a window with nothing served.
+   # Scoped to exactly what this invocation manages (generic plus each -M MAC);
+   # deliberately not a glob, since other boards' per-MAC files may share this root.
+   for stale in "$TFTP_ROOT/system.$otherFormat" \
+                ${macs[@]+"${macs[@]/#/$TFTP_ROOT/system.$otherFormat.}"}; do
+      [ -e "$stale" ] || continue
+      echo "Removing superseded $stale (.$otherFormat is not usable alongside .$bitFormat)"
+      rm -f "$stale"
+   done
+
+   # Without -M this run cannot know the board's MAC, so it can only clean the
+   # generic name above. Any per-MAC file left in the root outranks a generic one
+   # in loadpl_net's probe order, so a stale one would silently win over what was
+   # just staged. Flag them rather than guess which board they belong to.
+   if [ ${#macs[@]} -eq 0 ]; then
+      for leftover in "$TFTP_ROOT"/system.bit.* "$TFTP_ROOT"/system.bin.*; do
+         [ -e "$leftover" ] || continue
+         echo "WARNING: $leftover outranks $bitDest in loadpl_net's probe order." >&2
+         echo "         Re-run with -M <board-MAC> to refresh or remove it." >&2
+      done
+   fi
 fi

--- a/shared/Yocto/recipes-bsp/u-boot/files/bsp.cfg
+++ b/shared/Yocto/recipes-bsp/u-boot/files/bsp.cfg
@@ -14,7 +14,7 @@ CONFIG_I2C_EEPROM=y
 # 2026.01 (xilinx-v2026.1) .config; do not re-add these here.
 
 # Required by the tftp-only netboot bitstream step ('fpga load' in the
-# loadpl_net env of platform-top.h, which fetches system.bit.bin over TFTP and
+# loadpl_net env of platform-top.h, which fetches system.bit/system.bin over TFTP and
 # programs the PL via PCAP before booting the kernel FIT). These are normally
 # already on in the ZynqMP defconfig, but this feature hard-depends on them, so
 # pin them explicitly rather than rely on the defconfig staying that way.

--- a/shared/Yocto/recipes-bsp/u-boot/files/platform-top.h
+++ b/shared/Yocto/recipes-bsp/u-boot/files/platform-top.h
@@ -18,14 +18,24 @@
 	/* Bitstream fetch+program, run by netboot only in the tftp-only (diskless) */ \
 	/* build. 'setexpr gsub' rewrites ${ethaddr}'s colons to dashes into ${macfn} */ \
 	/* (U-Boot's tftpboot parses the first ':' in a filename as a hostIP separator, */ \
-	/* so a colon-form name is unusable). Tries the per-MAC file first */ \
-	/* (system.bit.bin.<mac-dashes>), then a generic system.bit.bin, then 'fpga */ \
-	/* load's the raw .bin to the PL via PCAP. Reuses 0x10000000 sequentially: fpga */ \
+	/* so a colon-form name is unusable). Probe order is most- to least-specific, */ \
+	/* preferring the Vivado .bit at each level: */ \
+	/*   system.bit.<mac-dashes> -> system.bin.<mac-dashes> -> system.bit -> system.bin */ \
+	/* then 'fpga load's whichever hit to the PL via PCAP. Both formats are accepted: */ \
+	/* on PMUFW > v1.0 zynqmp_load() skips zynqmp_validate_bitstream() entirely and */ \
+	/* hands the buffer verbatim to the PMU. The .bit is not just the .bin plus a */ \
+	/* ~222-byte header: bootgen also byte-reverses every 32-bit word (sync AA995566 */ \
+	/* vs 665599AA), so a .bit loads because the PCAP auto-detects bus width and */ \
+	/* endianness, and it costs ~16.6s versus ~0.2s for a .bin on a 34MB bitstream -- */ \
+	/* paid on every boot, since .bit is preferred. A .bit is rejected only on PMUFW */ \
+	/* <= v1.0, where the validator runs and fails the header-offset 'diff' check. */ \
+	/* A miss costs one immediate TFTP NAK, not a timeout, so the extra probes are */ \
+	/* effectively free. Reuses 0x10000000 sequentially: fpga */ \
 	/* load consumes the buffer before netboot fetches the kernel FIT to the same */ \
 	/* address. It is && so a total fetch or program failure aborts netboot before */ \
 	/* the kernel boots (never a net kernel over an unprogrammed PL). ${filesize} is */ \
 	/* set by whichever tftpboot succeeded. */ \
-	"loadpl_net=setexpr macfn gsub : - ${ethaddr} && if tftpboot 0x10000000 system.bit.bin.${macfn}; then true; else tftpboot 0x10000000 system.bit.bin; fi && fpga load 0 0x10000000 ${filesize}\0" \
+	"loadpl_net=setexpr macfn gsub : - ${ethaddr} && if tftpboot 0x10000000 system.bit.${macfn}; then true; elif tftpboot 0x10000000 system.bin.${macfn}; then true; elif tftpboot 0x10000000 system.bit; then true; else tftpboot 0x10000000 system.bin; fi && fpga load 0 0x10000000 ${filesize}\0" \
 	/* fallback build: no U-Boot bitstream load -- the SD's startup-app-init fpgautil */ \
 	/* owns the PL exactly as before (avoids a double-program). */ \
 	"loadpl_skip=true\0" \


### PR DESCRIPTION
> **Breaking (pre-release only):** the raw `.bin` TFTP artifact is renamed `system.bit.bin` → `system.bin`. Re-stage after reflashing. Never appeared in a tagged release, so no compatibility probe is kept — rationale below.

## Why

Field report: someone had been serving Vivado `.bit` files for the U-Boot TFTP bitstream load all along, having forgotten the bootgen conversion step, and it just worked. Our docs said the conversion was **required**, so either the docs were wrong or those boards were working by accident.

The docs were wrong.

## What's actually true

In `drivers/fpga/zynqmppl.c` (u-boot-xlnx 2026.01-xilinx-v2026.1), `zynqmp_load()` calls its format validator **only** on ancient PMU firmware:

```c
if (zynqmp_firmware_version() <= PMUFW_V1_0) {
        ...
        if (zynqmp_validate_bitstream(desc, buf, bsize, bsize, &swap))
                return FPGA_FAIL;
        ...
} else {
        bstype = 0;          /* modern PMUFW: no validation at all */
}
```

On current PMUFW the `else` branch is taken: no sync-word scan, no byte-swap, no format check. The buffer goes verbatim to the PMU via `PM_FPGA_LOAD`, and the PMU's PCAP loader skips the Vivado header itself.

Corroborated by sizes already recorded in `NETBOOT_BRINGUP_NOTES.md`: `system.bit` = 34,437,578 B vs the staged raw `.bin` = 34,437,356 B — a delta of exactly **222 bytes**, the header. Same payload, different wrapper.

## Renaming `system.bit.bin` to `system.bin`

The old name read as "bit dot bin" and existed only because the format was believed to matter. Now that either format loads, the name should just track the extension:

| Probe order | Content |
|---|---|
| `system.bit.<mac>` | Vivado `.bit`, per-board |
| `system.bin.<mac>` | raw `.bin`, per-board |
| `system.bit` | Vivado `.bit` |
| `system.bin` | raw `.bin` |

**Clean break, no compatibility probe.** The netboot feature has never been merged to `main` and is absent from the latest tag `6.5.0` (2026-06-30) — PR #107 landed on `pre-release` on 2026-07-15. So `system.bit.bin` has never appeared in a release. This is the last moment the rename is free.

Anyone running netboot from `pre-release` in the lab today needs a `BOOT.BIN` reflash for the new probe order anyway; re-staging under the new names is a single `cp`.

## Changes

- **`platform-top.h`** — `loadpl_net` probes the four names above using `elif` (supported by the hush parser in this tree). The `&&` failure chain is untouched, so a `tftp-only` board still halts rather than boot a kernel over an unprogrammed PL. The `@LOADPL_SEL@` substitution is unaffected.
- **`tftp_network_boot.rst`** — removes the "needs the raw PL configuration `.bin`" claim, leads with the no-conversion path, and adds a **"Bitstream formats: `.bit` and `.bin`"** section with the driver excerpt, the PMUFW caveat, and the precedence rule.
- **`provision_tftp_host.sh`** — output filenames change to `system.bin` / `system.bin.<mac>`; otherwise comments and `-H` text only. `-B`/`-M` still convert via bootgen.
- **`bsp.cfg`** — comment reference updated.
- **`NETBOOT_BRINGUP_NOTES.md`** — records the PMUFW-gated validator finding and renames throughout, including the Stage A transcripts. Those record observed *behavior* (per-MAC fetch, generic fallback, halt-on-failure, the colon mis-parse), none of which depends on the literal filename, so there is no reason to preserve a name that never shipped.

## Reviewer attention

- **Requires a rebuild and reflash of `BOOT.BIN`.** Until then a board asks for the old `system.bit.bin` only — and will still happily load a `.bit` that has been *named* `system.bit.bin`, which is what the original reporter was unknowingly doing.
- **New precedence footgun.** Preferring `.bit` means a stale hand-copied `/tftpboot/system.bit` now silently outranks a freshly script-staged `system.bin`. Documented in the design notes and as a troubleshooting row. Flipping to `.bin`-first would remove it, at the cost of the preference.
- `-B` still hard-requires `bootgen` on `PATH`. That friction is likely what caused the original confusion, but removing it was explicitly out of scope.